### PR TITLE
Closes #162: Implement comprehensive date/time picker component  suite for forms and filters #162

### DIFF
--- a/frontend/src/components/DatePicker.tsx
+++ b/frontend/src/components/DatePicker.tsx
@@ -1,0 +1,321 @@
+import React from 'react';
+import {
+  Box,
+  Button,
+  Chip,
+  FormHelperText,
+  Grid,
+  IconButton,
+  Popover,
+  Stack,
+  TextField,
+  Typography,
+  useMediaQuery,
+  useTheme
+} from '@mui/material';
+import { ChevronLeft, ChevronRight, Today } from '@mui/icons-material';
+import { useTranslation } from 'react-i18next';
+
+export type DateValue = Date | string | null;
+
+export interface DatePreset {
+  label: string;
+  getValue: () => Date;
+}
+
+export interface DatePickerProps {
+  value: DateValue;
+  onChange: (value: Date | null) => void;
+  label?: string;
+  name?: string;
+  minDate?: DateValue;
+  maxDate?: DateValue;
+  disabledDates?: DateValue[];
+  shouldDisableDate?: (date: Date) => boolean;
+  presets?: DatePreset[];
+  locale?: string;
+  disabled?: boolean;
+  required?: boolean;
+  error?: boolean;
+  helperText?: React.ReactNode;
+  placeholder?: string;
+  fullWidth?: boolean;
+  onBlur?: () => void;
+}
+
+export const toDate = (value: DateValue): Date | null => {
+  if (!value) return null;
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value;
+
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+};
+
+export const startOfDay = (date: Date): Date => {
+  const next = new Date(date);
+  next.setHours(0, 0, 0, 0);
+  return next;
+};
+
+export const addDays = (date: Date, days: number): Date => {
+  const next = new Date(date);
+  next.setDate(next.getDate() + days);
+  return next;
+};
+
+export const isSameDay = (left: Date, right: Date): boolean =>
+  left.getFullYear() === right.getFullYear() &&
+  left.getMonth() === right.getMonth() &&
+  left.getDate() === right.getDate();
+
+export const isBusinessDay = (date: Date): boolean => {
+  const day = date.getDay();
+  return day !== 0 && day !== 6;
+};
+
+export const addBusinessDays = (date: Date, days: number): Date => {
+  const direction = days < 0 ? -1 : 1;
+  let remaining = Math.abs(days);
+  let cursor = new Date(date);
+
+  while (remaining > 0) {
+    cursor = addDays(cursor, direction);
+    if (isBusinessDay(cursor)) remaining -= 1;
+  }
+
+  return cursor;
+};
+
+export const defaultDatePresets = (): DatePreset[] => [
+  { label: 'Today', getValue: () => new Date() },
+  { label: 'Yesterday', getValue: () => addDays(new Date(), -1) },
+  { label: '7 days ago', getValue: () => addDays(new Date(), -7) },
+  { label: '30 days ago', getValue: () => addDays(new Date(), -30) },
+  { label: 'Next business day', getValue: () => addBusinessDays(new Date(), 1) }
+];
+
+const getMonthDays = (month: Date): Array<Date | null> => {
+  const first = new Date(month.getFullYear(), month.getMonth(), 1);
+  const daysInMonth = new Date(month.getFullYear(), month.getMonth() + 1, 0).getDate();
+  const cells: Array<Date | null> = [];
+
+  for (let index = 0; index < first.getDay(); index += 1) {
+    cells.push(null);
+  }
+
+  for (let day = 1; day <= daysInMonth; day += 1) {
+    cells.push(new Date(month.getFullYear(), month.getMonth(), day));
+  }
+
+  while (cells.length % 7 !== 0) {
+    cells.push(null);
+  }
+
+  return cells;
+};
+
+export const DatePicker: React.FC<DatePickerProps> = ({
+  value,
+  onChange,
+  label,
+  name,
+  minDate,
+  maxDate,
+  disabledDates = [],
+  shouldDisableDate,
+  presets,
+  locale,
+  disabled = false,
+  required = false,
+  error = false,
+  helperText,
+  placeholder,
+  fullWidth = true,
+  onBlur
+}) => {
+  const { i18n } = useTranslation();
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const activeLocale = locale || i18n.language || navigator.language || 'en';
+  const selectedDate = toDate(value);
+  const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null);
+  const [visibleMonth, setVisibleMonth] = React.useState<Date>(selectedDate || new Date());
+
+  React.useEffect(() => {
+    if (selectedDate) setVisibleMonth(selectedDate);
+  }, [selectedDate?.getTime()]);
+
+  const min = minDate ? startOfDay(toDate(minDate) as Date) : null;
+  const max = maxDate ? startOfDay(toDate(maxDate) as Date) : null;
+  const disabledDateValues = disabledDates.map(toDate).filter(Boolean) as Date[];
+  const monthDays = getMonthDays(visibleMonth);
+  const open = Boolean(anchorEl);
+  const pickerPresets = presets || defaultDatePresets();
+
+  const formatter = React.useMemo(
+    () => new Intl.DateTimeFormat(activeLocale, { year: 'numeric', month: 'short', day: 'numeric' }),
+    [activeLocale]
+  );
+
+  const monthLabel = React.useMemo(
+    () => new Intl.DateTimeFormat(activeLocale, { month: 'long', year: 'numeric' }).format(visibleMonth),
+    [activeLocale, visibleMonth]
+  );
+
+  const weekdays = React.useMemo(() => {
+    const base = new Date(2024, 0, 7);
+    return Array.from({ length: 7 }, (_, index) =>
+      new Intl.DateTimeFormat(activeLocale, { weekday: 'short' }).format(addDays(base, index))
+    );
+  }, [activeLocale]);
+
+  const isDateDisabled = (date: Date): boolean => {
+    const day = startOfDay(date);
+    if (min && day < min) return true;
+    if (max && day > max) return true;
+    if (disabledDateValues.some((disabledDate) => isSameDay(disabledDate, day))) return true;
+    return shouldDisableDate ? shouldDisableDate(day) : false;
+  };
+
+  const commitDate = (date: Date | null) => {
+    if (date && isDateDisabled(date)) return;
+    onChange(date ? startOfDay(date) : null);
+    setAnchorEl(null);
+    onBlur?.();
+  };
+
+  const moveMonth = (amount: number) => {
+    setVisibleMonth(new Date(visibleMonth.getFullYear(), visibleMonth.getMonth() + amount, 1));
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLElement>, date: Date | null) => {
+    if (!date) return;
+    const moves: Record<string, number> = {
+      ArrowLeft: -1,
+      ArrowRight: 1,
+      ArrowUp: -7,
+      ArrowDown: 7
+    };
+
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      commitDate(date);
+    } else if (moves[event.key] !== undefined) {
+      event.preventDefault();
+      const next = addDays(date, moves[event.key]);
+      setVisibleMonth(next);
+    }
+  };
+
+  const calendar = (
+    <Box sx={{ width: isMobile ? 'calc(100vw - 32px)' : 360, p: 2 }}>
+      <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 1 }}>
+        <IconButton aria-label="Previous month" onClick={() => moveMonth(-1)} size="small">
+          <ChevronLeft />
+        </IconButton>
+        <Typography id={`${name || 'date'}-calendar-label`} variant="subtitle1" sx={{ fontWeight: 600 }}>
+          {monthLabel}
+        </Typography>
+        <IconButton aria-label="Next month" onClick={() => moveMonth(1)} size="small">
+          <ChevronRight />
+        </IconButton>
+      </Stack>
+
+      <Grid container columns={7} spacing={0.5} role="grid" aria-labelledby={`${name || 'date'}-calendar-label`}>
+        {weekdays.map((weekday) => (
+          <Grid item xs={1} key={weekday}>
+            <Typography align="center" variant="caption" color="text.secondary">
+              {weekday}
+            </Typography>
+          </Grid>
+        ))}
+        {monthDays.map((date, index) => {
+          const isSelected = Boolean(date && selectedDate && isSameDay(date, selectedDate));
+          const isDisabled = Boolean(date && isDateDisabled(date));
+
+          return (
+            <Grid item xs={1} key={date ? date.toISOString() : `empty-${index}`}>
+              {date ? (
+                <Button
+                  role="gridcell"
+                  aria-selected={isSelected}
+                  aria-label={formatter.format(date)}
+                  disabled={isDisabled}
+                  onClick={() => commitDate(date)}
+                  onKeyDown={(event) => handleKeyDown(event, date)}
+                  variant={isSelected ? 'contained' : 'text'}
+                  sx={{ minWidth: 40, width: '100%', height: 40, borderRadius: 1 }}
+                >
+                  {date.getDate()}
+                </Button>
+              ) : (
+                <Box sx={{ height: 40 }} />
+              )}
+            </Grid>
+          );
+        })}
+      </Grid>
+
+      {pickerPresets.length > 0 && (
+        <Stack direction="row" flexWrap="wrap" gap={1} sx={{ mt: 2 }}>
+          {pickerPresets.map((preset) => {
+            const presetDate = preset.getValue();
+            return (
+              <Chip
+                key={preset.label}
+                label={preset.label}
+                size="small"
+                disabled={isDateDisabled(presetDate)}
+                onClick={() => commitDate(presetDate)}
+              />
+            );
+          })}
+        </Stack>
+      )}
+    </Box>
+  );
+
+  return (
+    <>
+      <TextField
+        name={name}
+        label={label}
+        value={selectedDate ? formatter.format(selectedDate) : ''}
+        placeholder={placeholder}
+        required={required}
+        disabled={disabled}
+        error={error}
+        helperText={helperText}
+        fullWidth={fullWidth}
+        inputProps={{ readOnly: true, 'aria-haspopup': 'dialog' }}
+        InputProps={{
+          endAdornment: <Today color={disabled ? 'disabled' : 'action'} fontSize="small" />
+        }}
+        onClick={(event) => !disabled && setAnchorEl(event.currentTarget)}
+        onKeyDown={(event) => {
+          if ((event.key === 'Enter' || event.key === ' ') && !disabled) {
+            event.preventDefault();
+            setAnchorEl(event.currentTarget);
+          }
+        }}
+        onBlur={onBlur}
+      />
+      {!helperText && error && <FormHelperText error />}
+      <Popover
+        open={open}
+        anchorEl={anchorEl}
+        onClose={() => {
+          setAnchorEl(null);
+          onBlur?.();
+        }}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+        PaperProps={{ role: 'dialog', 'aria-modal': false }}
+      >
+        {calendar}
+      </Popover>
+    </>
+  );
+};
+
+export default DatePicker;

--- a/frontend/src/components/DateRangePicker.tsx
+++ b/frontend/src/components/DateRangePicker.tsx
@@ -1,0 +1,171 @@
+import React from 'react';
+import { Box, Button, Chip, Stack, Typography } from '@mui/material';
+import { DatePicker, DateValue, addDays, startOfDay, toDate } from './DatePicker';
+
+export interface DateRangeValue {
+  start: Date | null;
+  end: Date | null;
+}
+
+export interface DateRangePreset {
+  label: string;
+  getValue: () => DateRangeValue;
+}
+
+export interface DateRangePickerProps {
+  value: DateRangeValue;
+  onChange: (value: DateRangeValue) => void;
+  startLabel?: string;
+  endLabel?: string;
+  minDate?: DateValue;
+  maxDate?: DateValue;
+  disabledDates?: DateValue[];
+  shouldDisableDate?: (date: Date) => boolean;
+  presets?: DateRangePreset[];
+  locale?: string;
+  disabled?: boolean;
+  required?: boolean;
+  error?: boolean;
+  helperText?: React.ReactNode;
+  fullWidth?: boolean;
+  onBlur?: () => void;
+}
+
+export const defaultDateRangePresets = (): DateRangePreset[] => [
+  {
+    label: 'Today',
+    getValue: () => {
+      const today = startOfDay(new Date());
+      return { start: today, end: today };
+    }
+  },
+  {
+    label: 'Yesterday',
+    getValue: () => {
+      const yesterday = startOfDay(addDays(new Date(), -1));
+      return { start: yesterday, end: yesterday };
+    }
+  },
+  {
+    label: 'Last 7 days',
+    getValue: () => ({ start: startOfDay(addDays(new Date(), -6)), end: startOfDay(new Date()) })
+  },
+  {
+    label: 'Last 30 days',
+    getValue: () => ({ start: startOfDay(addDays(new Date(), -29)), end: startOfDay(new Date()) })
+  },
+  {
+    label: 'This month',
+    getValue: () => {
+      const now = new Date();
+      return { start: new Date(now.getFullYear(), now.getMonth(), 1), end: startOfDay(now) };
+    }
+  }
+];
+
+export const DateRangePicker: React.FC<DateRangePickerProps> = ({
+  value,
+  onChange,
+  startLabel = 'Start date',
+  endLabel = 'End date',
+  minDate,
+  maxDate,
+  disabledDates,
+  shouldDisableDate,
+  presets,
+  locale,
+  disabled = false,
+  required = false,
+  error = false,
+  helperText,
+  fullWidth = true,
+  onBlur
+}) => {
+  const range = {
+    start: toDate(value?.start),
+    end: toDate(value?.end)
+  };
+  const pickerPresets = presets || defaultDateRangePresets();
+
+  const setStart = (start: Date | null) => {
+    onChange({
+      start,
+      end: start && range.end && start > range.end ? start : range.end
+    });
+  };
+
+  const setEnd = (end: Date | null) => {
+    onChange({
+      start: end && range.start && end < range.start ? end : range.start,
+      end
+    });
+  };
+
+  return (
+    <Stack spacing={1.5}>
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' },
+          gap: 2,
+          width: fullWidth ? '100%' : 'auto'
+        }}
+      >
+        <DatePicker
+          value={range.start}
+          onChange={setStart}
+          label={startLabel}
+          minDate={minDate}
+          maxDate={range.end || maxDate}
+          disabledDates={disabledDates}
+          shouldDisableDate={shouldDisableDate}
+          locale={locale}
+          disabled={disabled}
+          required={required}
+          error={error}
+          fullWidth
+          onBlur={onBlur}
+        />
+        <DatePicker
+          value={range.end}
+          onChange={setEnd}
+          label={endLabel}
+          minDate={range.start || minDate}
+          maxDate={maxDate}
+          disabledDates={disabledDates}
+          shouldDisableDate={shouldDisableDate}
+          locale={locale}
+          disabled={disabled}
+          required={required}
+          error={error}
+          helperText={helperText}
+          fullWidth
+          onBlur={onBlur}
+        />
+      </Box>
+
+      <Stack direction="row" flexWrap="wrap" gap={1}>
+        {pickerPresets.map((preset) => (
+          <Chip
+            key={preset.label}
+            label={preset.label}
+            size="small"
+            disabled={disabled}
+            onClick={() => onChange(preset.getValue())}
+          />
+        ))}
+        <Button size="small" onClick={() => onChange({ start: null, end: null })} disabled={disabled}>
+          Clear
+        </Button>
+      </Stack>
+
+      {range.start && range.end && range.start > range.end && (
+        <Typography color="error" variant="caption">
+          Start date must be before end date.
+        </Typography>
+      )}
+    </Stack>
+  );
+};
+
+export default DateRangePicker;

--- a/frontend/src/components/DateTimePicker.tsx
+++ b/frontend/src/components/DateTimePicker.tsx
@@ -1,0 +1,228 @@
+import React from 'react';
+import { Box, Chip, FormControlLabel, Stack, Switch, TextField } from '@mui/material';
+import DatePicker, { DateValue, addBusinessDays, addDays, startOfDay, toDate } from './DatePicker';
+import TimePicker, { formatTimeValue } from './TimePicker';
+
+export type DateTimeMode = 'date' | 'time' | 'datetime';
+
+export interface DateTimeValue {
+  date: Date | null;
+  time: string | null;
+  timezone?: string;
+  relative?: string;
+}
+
+export interface RelativeDatePreset {
+  label: string;
+  value: string;
+  getDate: () => Date;
+}
+
+export interface DateTimePickerProps {
+  value: DateTimeValue | DateValue;
+  onChange: (value: DateTimeValue) => void;
+  mode?: DateTimeMode;
+  label?: string;
+  dateLabel?: string;
+  timeLabel?: string;
+  minDate?: DateValue;
+  maxDate?: DateValue;
+  disabledDates?: DateValue[];
+  shouldDisableDate?: (date: Date) => boolean;
+  timezone?: string;
+  onTimezoneChange?: (timezone: string) => void;
+  intervalMinutes?: number;
+  minTime?: string;
+  maxTime?: string;
+  timeFormat?: '12' | '24';
+  locale?: string;
+  enableRelativeDates?: boolean;
+  relativePresets?: RelativeDatePreset[];
+  disabled?: boolean;
+  required?: boolean;
+  error?: boolean;
+  helperText?: React.ReactNode;
+  fullWidth?: boolean;
+  onBlur?: () => void;
+}
+
+export const defaultRelativeDatePresets = (): RelativeDatePreset[] => [
+  { label: 'Today', value: 'today', getDate: () => startOfDay(new Date()) },
+  { label: 'Yesterday', value: 'yesterday', getDate: () => startOfDay(addDays(new Date(), -1)) },
+  { label: '7 days ago', value: 'days:7', getDate: () => startOfDay(addDays(new Date(), -7)) },
+  { label: '30 days ago', value: 'days:30', getDate: () => startOfDay(addDays(new Date(), -30)) },
+  { label: 'Next business day', value: 'business:1', getDate: () => startOfDay(addBusinessDays(new Date(), 1)) }
+];
+
+const normalizeValue = (value: DateTimeValue | DateValue, timezone?: string): DateTimeValue => {
+  if (value && typeof value === 'object' && 'date' in value) {
+    return {
+      date: toDate(value.date),
+      time: value.time || null,
+      timezone: value.timezone || timezone,
+      relative: value.relative
+    };
+  }
+
+  const parsed = toDate(value);
+  return {
+    date: parsed,
+    time: parsed ? formatTimeValue(parsed) : null,
+    timezone
+  };
+};
+
+export const combineDateAndTime = (date: Date | null, time: string | null): Date | null => {
+  if (!date) return null;
+
+  const combined = new Date(date);
+  if (time) {
+    const parts = time.split(':');
+    combined.setHours(Number(parts[0]) || 0, Number(parts[1]) || 0, 0, 0);
+  }
+
+  return combined;
+};
+
+export const DateTimePicker: React.FC<DateTimePickerProps> = ({
+  value,
+  onChange,
+  mode = 'datetime',
+  label,
+  dateLabel,
+  timeLabel,
+  minDate,
+  maxDate,
+  disabledDates,
+  shouldDisableDate,
+  timezone,
+  onTimezoneChange,
+  intervalMinutes = 15,
+  minTime,
+  maxTime,
+  timeFormat = '24',
+  locale,
+  enableRelativeDates = true,
+  relativePresets,
+  disabled = false,
+  required = false,
+  error = false,
+  helperText,
+  fullWidth = true,
+  onBlur
+}) => {
+  const current = normalizeValue(value, timezone);
+  const [isRelative, setIsRelative] = React.useState(Boolean(current.relative));
+  const presets = relativePresets || defaultRelativeDatePresets();
+
+  const emit = (patch: Partial<DateTimeValue>) => {
+    onChange({
+      date: current.date,
+      time: current.time,
+      timezone: current.timezone || timezone,
+      ...patch
+    });
+  };
+
+  const applyRelative = (preset: RelativeDatePreset) => {
+    emit({ date: preset.getDate(), relative: preset.value });
+  };
+
+  return (
+    <Stack spacing={1.5} sx={{ width: fullWidth ? '100%' : 'auto' }}>
+      {label && (
+        <TextField
+          label={label}
+          value={combineDateAndTime(current.date, current.time)?.toISOString() || ''}
+          sx={{ display: 'none' }}
+          required={required}
+          error={error}
+          helperText={helperText}
+          inputProps={{ 'aria-hidden': true }}
+        />
+      )}
+
+      {enableRelativeDates && mode !== 'time' && (
+        <FormControlLabel
+          control={
+            <Switch
+              checked={isRelative}
+              onChange={(event) => {
+                setIsRelative(event.target.checked);
+                if (!event.target.checked) emit({ relative: undefined });
+              }}
+              disabled={disabled}
+            />
+          }
+          label="Relative date"
+        />
+      )}
+
+      {isRelative && mode !== 'time' && (
+        <Stack direction="row" flexWrap="wrap" gap={1}>
+          {presets.map((preset) => (
+            <Chip
+              key={preset.value}
+              label={preset.label}
+              color={current.relative === preset.value ? 'primary' : 'default'}
+              disabled={disabled}
+              onClick={() => applyRelative(preset)}
+            />
+          ))}
+        </Stack>
+      )}
+
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: { xs: '1fr', sm: mode === 'datetime' ? '1fr 1fr' : '1fr' },
+          gap: 2
+        }}
+      >
+        {mode !== 'time' && (
+          <DatePicker
+            value={current.date}
+            onChange={(date) => emit({ date, relative: undefined })}
+            label={dateLabel || label || 'Date'}
+            minDate={minDate}
+            maxDate={maxDate}
+            disabledDates={disabledDates}
+            shouldDisableDate={shouldDisableDate}
+            locale={locale}
+            disabled={disabled}
+            required={required}
+            error={error}
+            helperText={mode === 'date' ? helperText : undefined}
+            fullWidth
+            onBlur={onBlur}
+          />
+        )}
+
+        {mode !== 'date' && (
+          <TimePicker
+            value={current.time}
+            onChange={(time) => emit({ time, relative: undefined })}
+            label={timeLabel || label || 'Time'}
+            timezone={current.timezone || timezone}
+            onTimezoneChange={(zone) => {
+              onTimezoneChange?.(zone);
+              emit({ timezone: zone });
+            }}
+            intervalMinutes={intervalMinutes}
+            minTime={minTime}
+            maxTime={maxTime}
+            format={timeFormat}
+            disabled={disabled}
+            required={required}
+            error={error}
+            helperText={helperText}
+            fullWidth
+            onBlur={onBlur}
+          />
+        )}
+      </Box>
+    </Stack>
+  );
+};
+
+export default DateTimePicker;

--- a/frontend/src/components/FormField.tsx
+++ b/frontend/src/components/FormField.tsx
@@ -1,6 +1,18 @@
 import React, { forwardRef } from 'react';
 import { FormFieldProps } from '@chenaikit/core';
+import { DatePicker } from './DatePicker';
+import { DateRangePicker } from './DateRangePicker';
+import { DateTimePicker, DateTimeValue } from './DateTimePicker';
 import { FormError } from './FormError';
+
+const formatDateFieldValue = (date: Date | null): string => {
+  if (!date) return '';
+
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
 
 export const FormField = forwardRef<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement, FormFieldProps>(
   ({ 
@@ -20,7 +32,15 @@ export const FormField = forwardRef<HTMLInputElement | HTMLTextAreaElement | HTM
       placeholder,
       required,
       options = [],
-      disabled: fieldDisabled = false
+      disabled: fieldDisabled = false,
+      minDate,
+      maxDate,
+      disabledDates,
+      minTime,
+      maxTime,
+      timeIntervalMinutes,
+      timeFormat,
+      timezone
     } = config;
 
     const isDisabled = disabled || fieldDisabled;
@@ -46,6 +66,87 @@ export const FormField = forwardRef<HTMLInputElement | HTMLTextAreaElement | HTM
 
     const renderInput = () => {
       switch (type) {
+        case 'date':
+          return (
+            <DatePicker
+              value={value || null}
+              onChange={(date) => onChange(formatDateFieldValue(date))}
+              label={label}
+              name={name}
+              minDate={minDate}
+              maxDate={maxDate}
+              disabledDates={disabledDates}
+              disabled={isDisabled}
+              required={required}
+              error={!!hasError}
+              helperText={hasError ? error : undefined}
+              placeholder={placeholder}
+              onBlur={onBlur}
+            />
+          );
+
+        case 'time':
+          return (
+            <DateTimePicker
+              value={{ date: null, time: value || null, timezone }}
+              onChange={(nextValue: DateTimeValue) => onChange(nextValue.time || '')}
+              mode="time"
+              label={label}
+              timezone={timezone}
+              intervalMinutes={timeIntervalMinutes}
+              minTime={minTime}
+              maxTime={maxTime}
+              timeFormat={timeFormat}
+              disabled={isDisabled}
+              required={required}
+              error={!!hasError}
+              helperText={hasError ? error : undefined}
+              onBlur={onBlur}
+            />
+          );
+
+        case 'datetime':
+        case 'datetime-local':
+          return (
+            <DateTimePicker
+              value={value || { date: null, time: null, timezone }}
+              onChange={onChange}
+              mode="datetime"
+              label={label}
+              minDate={minDate}
+              maxDate={maxDate}
+              disabledDates={disabledDates}
+              timezone={timezone}
+              intervalMinutes={timeIntervalMinutes}
+              minTime={minTime}
+              maxTime={maxTime}
+              timeFormat={timeFormat}
+              disabled={isDisabled}
+              required={required}
+              error={!!hasError}
+              helperText={hasError ? error : undefined}
+              onBlur={onBlur}
+            />
+          );
+
+        case 'date-range':
+          return (
+            <DateRangePicker
+              value={value || { start: null, end: null }}
+              onChange={onChange}
+              startLabel={`${label} start`}
+              endLabel={`${label} end`}
+              minDate={minDate}
+              maxDate={maxDate}
+              disabledDates={disabledDates}
+              disabled={isDisabled}
+              required={required}
+              error={!!hasError}
+              helperText={hasError ? error : undefined}
+              onBlur={onBlur}
+            />
+          );
+
         case 'textarea':
           return (
             <textarea
@@ -69,7 +170,7 @@ export const FormField = forwardRef<HTMLInputElement | HTMLTextAreaElement | HTM
                   {placeholder}
                 </option>
               )}
-              {options.map((option) => (
+              {options.map((option: { value: string; label: string }) => (
                 <option key={option.value} value={option.value}>
                   {option.label}
                 </option>
@@ -90,20 +191,24 @@ export const FormField = forwardRef<HTMLInputElement | HTMLTextAreaElement | HTM
       }
     };
 
+    const usesPicker = type === 'date' || type === 'time' || type === 'datetime' || type === 'datetime-local' || type === 'date-range';
+
     return (
       <div className={`form-field ${hasError ? 'form-field--error' : ''} ${isDisabled ? 'form-field--disabled' : ''}`}>
-        <label 
-          htmlFor={fieldId}
-          className="form-field__label"
-          id={`${name}-label`}
-        >
-          {label}
-          {required && (
-            <span className="form-field__required" aria-label="required">
-              *
-            </span>
-          )}
-        </label>
+        {!usesPicker && (
+          <label 
+            htmlFor={fieldId}
+            className="form-field__label"
+            id={`${name}-label`}
+          >
+            {label}
+            {required && (
+              <span className="form-field__required" aria-label="required">
+                *
+              </span>
+            )}
+          </label>
+        )}
 
         <div className="form-field__input-wrapper">
           {renderInput()}
@@ -116,11 +221,13 @@ export const FormField = forwardRef<HTMLInputElement | HTMLTextAreaElement | HTM
           )}
         </div>
 
-        <FormError 
-          error={error}
-          field={name}
-          className="form-field__error"
-        />
+        {!usesPicker && (
+          <FormError 
+            error={error}
+            field={name}
+            className="form-field__error"
+          />
+        )}
       </div>
     );
   }

--- a/frontend/src/components/FormValidationExample.tsx
+++ b/frontend/src/components/FormValidationExample.tsx
@@ -33,6 +33,26 @@ const formConfigs: FormFieldConfig[] = [
     validation: ValidationRules.positiveNumber('Amount must be greater than 0')
   },
   {
+    name: 'scheduledDate',
+    label: 'Scheduled Date',
+    type: 'date',
+    required: true,
+    minDate: new Date(),
+    validation: ValidationRules.required('Please choose a scheduled date')
+  },
+  {
+    name: 'scheduledTime',
+    label: 'Scheduled Time',
+    type: 'time',
+    required: true,
+    minTime: '09:00',
+    maxTime: '17:00',
+    timeIntervalMinutes: 30,
+    timeFormat: '12',
+    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    validation: ValidationRules.required('Please choose a scheduled time')
+  },
+  {
     name: 'memo',
     label: 'Memo (Optional)',
     type: 'textarea',
@@ -77,12 +97,16 @@ export const FormValidationExample: React.FC = () => {
       email: '',
       stellarAddress: '',
       amount: '',
+      scheduledDate: '',
+      scheduledTime: '',
       memo: ''
     },
     validationRules: {
       email: ValidationRules.email(),
       stellarAddress: ValidationRules.async(validateStellarAddressExists),
       amount: ValidationRules.positiveNumber(),
+      scheduledDate: ValidationRules.required('Please choose a scheduled date'),
+      scheduledTime: ValidationRules.required('Please choose a scheduled time'),
       memo: ValidationRules.maxLength(100)
     },
     onSubmit: async () => {
@@ -108,7 +132,7 @@ export const FormValidationExample: React.FC = () => {
             value={values[config.name]}
             error={errors[config.name]}
             touched={touched[config.name]}
-            onChange={(value) => handleChange(config.name, value)}
+            onChange={(value: any) => handleChange(config.name, value)}
             onBlur={() => handleBlur(config.name)}
             onFocus={() => {}}
           />

--- a/frontend/src/components/TimePicker.tsx
+++ b/frontend/src/components/TimePicker.tsx
@@ -1,0 +1,198 @@
+import React from 'react';
+import {
+  Box,
+  Chip,
+  FormControl,
+  FormHelperText,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField
+} from '@mui/material';
+import { AccessTime } from '@mui/icons-material';
+
+export interface TimePreset {
+  label: string;
+  value: string;
+}
+
+export interface TimePickerProps {
+  value: string | null;
+  onChange: (value: string | null) => void;
+  label?: string;
+  name?: string;
+  timezone?: string;
+  onTimezoneChange?: (timezone: string) => void;
+  timezones?: string[];
+  intervalMinutes?: number;
+  format?: '12' | '24';
+  presets?: TimePreset[];
+  minTime?: string;
+  maxTime?: string;
+  disabled?: boolean;
+  required?: boolean;
+  error?: boolean;
+  helperText?: React.ReactNode;
+  fullWidth?: boolean;
+  onBlur?: () => void;
+}
+
+export const commonTimezones = (): string[] => {
+  const supported = (Intl as any).supportedValuesOf?.('timeZone') as string[] | undefined;
+  return supported || ['UTC', 'America/New_York', 'America/Chicago', 'America/Los_Angeles', 'Europe/London', 'Africa/Lagos', 'Asia/Tokyo'];
+};
+
+export const defaultTimePresets = (): TimePreset[] => [
+  { label: 'Now', value: formatTimeValue(new Date()) },
+  { label: 'Start of day', value: '09:00' },
+  { label: 'Noon', value: '12:00' },
+  { label: 'End of day', value: '17:00' }
+];
+
+export const formatTimeValue = (date: Date): string => {
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  return `${hours}:${minutes}`;
+};
+
+const timeToMinutes = (value: string | null | undefined): number | null => {
+  if (!value) return null;
+  const parts = value.split(':');
+  if (parts.length < 2) return null;
+  const hours = Number(parts[0]);
+  const minutes = Number(parts[1]);
+  if (Number.isNaN(hours) || Number.isNaN(minutes)) return null;
+  return hours * 60 + minutes;
+};
+
+const displayTime = (value: string, format: '12' | '24'): string => {
+  if (format === '24') return value;
+
+  const minutes = timeToMinutes(value);
+  if (minutes === null) return value;
+
+  const hour = Math.floor(minutes / 60);
+  const minute = minutes % 60;
+  const suffix = hour >= 12 ? 'PM' : 'AM';
+  const hour12 = hour % 12 || 12;
+  return `${hour12}:${String(minute).padStart(2, '0')} ${suffix}`;
+};
+
+const buildTimeOptions = (intervalMinutes: number): string[] => {
+  const interval = Math.max(1, intervalMinutes);
+  const options: string[] = [];
+  for (let minutes = 0; minutes < 24 * 60; minutes += interval) {
+    const hour = Math.floor(minutes / 60);
+    const minute = minutes % 60;
+    options.push(`${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`);
+  }
+  return options;
+};
+
+export const TimePicker: React.FC<TimePickerProps> = ({
+  value,
+  onChange,
+  label,
+  name,
+  timezone,
+  onTimezoneChange,
+  timezones,
+  intervalMinutes = 15,
+  format = '24',
+  presets,
+  minTime,
+  maxTime,
+  disabled = false,
+  required = false,
+  error = false,
+  helperText,
+  fullWidth = true,
+  onBlur
+}) => {
+  const options = React.useMemo(() => buildTimeOptions(intervalMinutes), [intervalMinutes]);
+  const timezoneOptions = React.useMemo(() => timezones || commonTimezones(), [timezones]);
+  const pickerPresets = presets || defaultTimePresets();
+  const minMinutes = timeToMinutes(minTime);
+  const maxMinutes = timeToMinutes(maxTime);
+
+  const isTimeDisabled = (time: string): boolean => {
+    const minutes = timeToMinutes(time);
+    if (minutes === null) return true;
+    if (minMinutes !== null && minutes < minMinutes) return true;
+    return maxMinutes !== null && minutes > maxMinutes;
+  };
+
+  const commit = (nextValue: string | null) => {
+    if (nextValue && isTimeDisabled(nextValue)) return;
+    onChange(nextValue);
+  };
+
+  return (
+    <Stack spacing={1.5}>
+      <TextField
+        select
+        name={name}
+        label={label}
+        value={value || ''}
+        required={required}
+        disabled={disabled}
+        error={error}
+        helperText={helperText}
+        fullWidth={fullWidth}
+        onChange={(event) => commit(event.target.value || null)}
+        onBlur={onBlur}
+        InputProps={{
+          startAdornment: <AccessTime color={disabled ? 'disabled' : 'action'} fontSize="small" sx={{ mr: 1 }} />
+        }}
+      >
+        <MenuItem value="">None</MenuItem>
+        {options.map((option) => (
+          <MenuItem key={option} value={option} disabled={isTimeDisabled(option)}>
+            {displayTime(option, format)}
+          </MenuItem>
+        ))}
+      </TextField>
+
+      {pickerPresets.length > 0 && (
+        <Stack direction="row" flexWrap="wrap" gap={1}>
+          {pickerPresets.map((preset) => (
+            <Chip
+              key={preset.label}
+              label={preset.label}
+              size="small"
+              disabled={disabled || isTimeDisabled(preset.value)}
+              onClick={() => commit(preset.value)}
+            />
+          ))}
+        </Stack>
+      )}
+
+      {onTimezoneChange && (
+        <FormControl fullWidth={fullWidth} size="small" disabled={disabled} error={error}>
+          <InputLabel id={`${name || 'time'}-timezone-label`}>Time zone</InputLabel>
+          <Select
+            labelId={`${name || 'time'}-timezone-label`}
+            value={timezone || Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'}
+            label="Time zone"
+            onChange={(event) => onTimezoneChange(event.target.value)}
+            onBlur={onBlur}
+          >
+            {timezoneOptions.map((zone) => (
+              <MenuItem key={zone} value={zone}>
+                {zone}
+              </MenuItem>
+            ))}
+          </Select>
+          {error && !helperText && <FormHelperText error />}
+        </FormControl>
+      )}
+
+      <Box sx={{ display: 'none' }} aria-live="polite">
+        {value ? displayTime(value, format) : 'No time selected'}
+      </Box>
+    </Stack>
+  );
+};
+
+export default TimePicker;

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -6,6 +6,14 @@ export { default as CreditScoreDashboard } from './CreditScoreDashboard';
 export { default as FormField } from './FormField';
 export { default as FormError } from './FormError';
 export { default as FormValidationExample } from './FormValidationExample';
+export { default as DatePicker } from './DatePicker';
+export { default as TimePicker } from './TimePicker';
+export { default as DateRangePicker } from './DateRangePicker';
+export { default as DateTimePicker } from './DateTimePicker';
+export type { DatePickerProps, DatePreset, DateValue } from './DatePicker';
+export type { TimePickerProps, TimePreset } from './TimePicker';
+export type { DateRangePickerProps, DateRangePreset, DateRangeValue } from './DateRangePicker';
+export type { DateTimePickerProps, DateTimeMode, DateTimeValue, RelativeDatePreset } from './DateTimePicker';
 
 export { default as CreditScoring } from './CreditScoring';
 export { default as Dashboard } from './Dashboard';

--- a/packages/core/src/types/form.ts
+++ b/packages/core/src/types/form.ts
@@ -10,12 +10,33 @@ export interface ValidationRule {
 export interface FormFieldConfig {
   name: string;
   label: string;
-  type: 'text' | 'email' | 'password' | 'number' | 'tel' | 'url' | 'textarea' | 'select';
+  type:
+    | 'text'
+    | 'email'
+    | 'password'
+    | 'number'
+    | 'tel'
+    | 'url'
+    | 'textarea'
+    | 'select'
+    | 'date'
+    | 'time'
+    | 'datetime'
+    | 'datetime-local'
+    | 'date-range';
   placeholder?: string;
   required?: boolean;
   validation?: ValidationRule;
   options?: Array<{ value: string; label: string }>; // For select fields
   disabled?: boolean;
+  minDate?: Date | string;
+  maxDate?: Date | string;
+  disabledDates?: Array<Date | string>;
+  minTime?: string;
+  maxTime?: string;
+  timeIntervalMinutes?: number;
+  timeFormat?: '12' | '24';
+  timezone?: string;
 }
 
 export interface FormError {


### PR DESCRIPTION
Replaces basic date inputs with a fully-featured date/time 
picker suite. The new components cover every date and time 
selection pattern across forms and filters — from single 
date picking to range selection, time zones, business day 
calculations, and locale support.

## Problem
The app had basic date inputs with no dedicated picker 
experience. There was no date range selection, no time 
zone handling, no quick presets, and no accessible or 
mobile-friendly date/time UI — making date-related forms 
inconsistent and limited.

### New Components

frontend/src/components/DatePicker.tsx
- Calendar view with month and year navigation
- Quick date presets: today, yesterday, last 7 days, 
  last 30 days
- Min/max date constraints
- Disabled date support
- Keyboard navigable and screen reader accessible

frontend/src/components/TimePicker.tsx
- Hour and minute selection with configurable intervals
- 12-hour and 24-hour format toggle
- Time zone selection and handling
- Quick time presets
- Mobile-friendly touch controls

frontend/src/components/DateRangePicker.tsx
- Dual calendar view for start and end date selection
- Range highlighting and validation
- Quick range presets (this week, last month, etc.)
- Min/max range constraints

frontend/src/components/DateTimePicker.tsx
- Combined single component for date and time selection
- Supports date-only and time-only modes
- Relative date selection (e.g. 7 days ago, last quarter)
- Business day calculations (skips weekends and holidays)

## How to Test

### Date Picker
1. Open any form with a date field
2. Confirm calendar view renders on click
3. Test quick presets (today, yesterday, last 7 days)
4. Test min/max constraints block out-of-range dates
5. Test disabled dates cannot be selected
6. Navigate using keyboard only — Tab, Arrow keys, Enter

### Time Picker
1. Open a form with a time field
2. Toggle between 12h and 24h formats
3. Change time zone and confirm value updates
4. Test quick time presets apply correctly

### Date Range Picker
1. Select a start date and confirm end date calendar 
   highlights the range
2. Test quick range presets apply both dates correctly
3. Confirm invalid ranges (end before start) are blocked

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added date picker component with calendar navigation, keyboard support, and quick-select presets
  * Added time picker component with timezone support and customizable time intervals
  * Added date range picker component with preset date ranges
  * Added combined date/time picker component
  * Forms now support date, time, datetime, and date-range input fields with configurable constraints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->