### PR TITLE
feat(backend): add email notification system

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,4 +1,35 @@
 SENTRY_DSN=https://your-sentry-dsn@sentry.io/project-id
+
+# ── Email ────────────────────────────────────────────────────────────────────
+# Provider: smtp | sendgrid | mailgun | ses  (default: smtp)
+EMAIL_PROVIDER=smtp
+EMAIL_FROM=noreply@chenaikit.io
+EMAIL_FROM_NAME=ChenAIKit
+EMAIL_REPLY_TO=support@chenaikit.io
+
+# SMTP (used when EMAIL_PROVIDER=smtp)
+SMTP_HOST=localhost
+SMTP_PORT=587
+SMTP_SECURE=false
+SMTP_USER=
+SMTP_PASS=
+
+# SendGrid (used when EMAIL_PROVIDER=sendgrid)
+SENDGRID_API_KEY=
+
+# Mailgun (used when EMAIL_PROVIDER=mailgun)
+MAILGUN_API_KEY=
+MAILGUN_DOMAIN=
+
+# AWS SES (used when EMAIL_PROVIDER=ses)
+AWS_SES_REGION=us-east-1
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+
+# Email queue (optional — overrides defaults)
+EMAIL_QUEUE_CONCURRENCY=5
+EMAIL_QUEUE_MAX_ATTEMPTS=3
+EMAIL_QUEUE_BACKOFF_MS=5000
 NODE_ENV=production
 REDIS_URL=redis://localhost:6379
 AI_API_KEY=your-ai-api-key

--- a/backend/package.json
+++ b/backend/package.json
@@ -40,6 +40,7 @@
     "typeorm": "^1.0.0",
     "uuid": "^9.0.1",
     "winston": "^3.14.2",
+    "nodemailer": "^6.9.0",
     "zod": "^3.22.0"
   },
   "devDependencies": {
@@ -58,6 +59,7 @@
     "jest": "^29.0.0",
     "prisma": "^5.0.0",
     "ts-node": "^10.9.0",
+    "@types/nodemailer": "^6.4.0",
     "typescript": "^5.0.0"
   }
 }

--- a/backend/src/config/email.ts
+++ b/backend/src/config/email.ts
@@ -1,0 +1,94 @@
+import { z } from 'zod';
+
+export type EmailProvider = 'smtp' | 'sendgrid' | 'mailgun' | 'ses';
+
+const EmailConfigSchema = z.object({
+  provider: z.enum(['smtp', 'sendgrid', 'mailgun', 'ses']).default('smtp'),
+  from: z.string().email().default('noreply@chenaikit.io'),
+  fromName: z.string().default('ChenAIKit'),
+  replyTo: z.string().email().optional(),
+
+  // SMTP
+  smtp: z
+    .object({
+      host: z.string(),
+      port: z.number(),
+      secure: z.boolean().default(false),
+      user: z.string().optional(),
+      pass: z.string().optional(),
+    })
+    .optional(),
+
+  // SendGrid
+  sendgridApiKey: z.string().optional(),
+
+  // Mailgun
+  mailgun: z
+    .object({
+      apiKey: z.string(),
+      domain: z.string(),
+    })
+    .optional(),
+
+  // AWS SES
+  ses: z
+    .object({
+      region: z.string(),
+      accessKeyId: z.string(),
+      secretAccessKey: z.string(),
+    })
+    .optional(),
+
+  // Queue settings
+  queue: z
+    .object({
+      concurrency: z.number().default(5),
+      maxAttempts: z.number().default(3),
+      backoffDelayMs: z.number().default(5000),
+    })
+    .default({}),
+});
+
+export type EmailConfig = z.infer<typeof EmailConfigSchema>;
+
+export function getEmailConfig(): EmailConfig {
+  return EmailConfigSchema.parse({
+    provider: process.env.EMAIL_PROVIDER,
+    from: process.env.EMAIL_FROM,
+    fromName: process.env.EMAIL_FROM_NAME,
+    replyTo: process.env.EMAIL_REPLY_TO,
+
+    smtp: process.env.SMTP_HOST
+      ? {
+          host: process.env.SMTP_HOST,
+          port: Number(process.env.SMTP_PORT ?? 587),
+          secure: process.env.SMTP_SECURE === 'true',
+          user: process.env.SMTP_USER,
+          pass: process.env.SMTP_PASS,
+        }
+      : undefined,
+
+    sendgridApiKey: process.env.SENDGRID_API_KEY,
+
+    mailgun: process.env.MAILGUN_API_KEY
+      ? {
+          apiKey: process.env.MAILGUN_API_KEY,
+          domain: process.env.MAILGUN_DOMAIN ?? '',
+        }
+      : undefined,
+
+    ses: process.env.AWS_SES_REGION
+      ? {
+          region: process.env.AWS_SES_REGION,
+          accessKeyId: process.env.AWS_ACCESS_KEY_ID ?? '',
+          secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY ?? '',
+        }
+      : undefined,
+
+    queue: {
+      concurrency: Number(process.env.EMAIL_QUEUE_CONCURRENCY ?? 5),
+      maxAttempts: Number(process.env.EMAIL_QUEUE_MAX_ATTEMPTS ?? 3),
+      backoffDelayMs: Number(process.env.EMAIL_QUEUE_BACKOFF_MS ?? 5000),
+    },
+  });
+}

--- a/backend/src/jobs/sendEmail.ts
+++ b/backend/src/jobs/sendEmail.ts
@@ -1,0 +1,64 @@
+import Queue from 'bull';
+import { getEmailConfig } from '../config/email';
+import { getEmailService, type SendEmailOptions } from '../services/emailService';
+import { log } from '../utils/logger';
+
+export type EmailJobData = SendEmailOptions & { _jobId?: string };
+
+let emailQueue: Queue.Queue<EmailJobData> | null = null;
+
+function getQueue(): Queue.Queue<EmailJobData> {
+  if (emailQueue) return emailQueue;
+
+  const redisUrl = process.env.REDIS_URL ?? 'redis://localhost:6379';
+  const cfg = getEmailConfig();
+
+  emailQueue = new Queue<EmailJobData>('email', redisUrl, {
+    defaultJobOptions: {
+      attempts: cfg.queue.maxAttempts,
+      backoff: { type: 'exponential', delay: cfg.queue.backoffDelayMs },
+      removeOnComplete: true,
+      removeOnFail: false,
+    },
+  });
+
+  emailQueue.process(cfg.queue.concurrency, async (job) => {
+    const service = getEmailService();
+    const result = await service.send(job.data);
+    log.info('[email-queue] job completed', { jobId: job.id, messageId: result.messageId });
+    return result;
+  });
+
+  emailQueue.on('failed', (job, err) => {
+    log.error('[email-queue] job failed', err, { jobId: job.id, to: job.data.to });
+  });
+
+  emailQueue.on('stalled', (job) => {
+    log.warn('[email-queue] job stalled', { jobId: job.id });
+  });
+
+  return emailQueue;
+}
+
+/**
+ * Enqueue an email to be sent asynchronously via the Bull job queue.
+ */
+export async function enqueueEmail(options: SendEmailOptions): Promise<Queue.Job<EmailJobData>> {
+  const queue = getQueue();
+  const job = await queue.add(options);
+  log.info('[email-queue] enqueued', { jobId: job.id, to: options.to, subject: options.subject });
+  return job;
+}
+
+/**
+ * Drain and close the email queue (for graceful shutdown).
+ */
+export async function closeEmailQueue(): Promise<void> {
+  if (emailQueue) {
+    await emailQueue.close();
+    emailQueue = null;
+    log.info('[email-queue] closed');
+  }
+}
+
+export { getQueue as getEmailQueue };

--- a/backend/src/services/__tests__/emailService.test.ts
+++ b/backend/src/services/__tests__/emailService.test.ts
@@ -1,0 +1,120 @@
+import { EmailService } from '../emailService';
+import type { EmailConfig } from '../../config/email';
+
+const testConfig: EmailConfig = {
+  provider: 'smtp',
+  from: 'test@chenaikit.io',
+  fromName: 'ChenAIKit Test',
+  smtp: { host: 'localhost', port: 1025, secure: false },
+  queue: { concurrency: 1, maxAttempts: 1, backoffDelayMs: 100 },
+};
+
+// Replace the transporter with a stub so no real SMTP calls are made.
+function makeService() {
+  const service = new EmailService(testConfig);
+  const sent: unknown[] = [];
+  // @ts-expect-error — accessing private field for testing
+  service.transporter = {
+    sendMail: async (opts: unknown) => {
+      sent.push(opts);
+      return { messageId: 'test-id-123', accepted: [(opts as any).to].flat(), rejected: [] };
+    },
+    verify: async () => true,
+  };
+  return { service, sent };
+}
+
+describe('EmailService', () => {
+  describe('send()', () => {
+    it('sends to a single valid recipient', async () => {
+      const { service, sent } = makeService();
+      const result = await service.send({ to: 'alice@example.com', subject: 'Hello', text: 'Hi' });
+      expect(result.messageId).toBe('test-id-123');
+      expect(result.accepted).toContain('alice@example.com');
+      expect(sent).toHaveLength(1);
+    });
+
+    it('sends to multiple recipients', async () => {
+      const { service, sent } = makeService();
+      await service.send({ to: ['a@x.com', 'b@x.com'], subject: 'Bulk', text: 'Hi' });
+      expect(sent).toHaveLength(1);
+      expect((sent[0] as any).to).toEqual(['a@x.com', 'b@x.com']);
+    });
+
+    it('skips invalid email addresses', async () => {
+      const { service, sent } = makeService();
+      await service.send({ to: ['good@x.com', 'not-an-email'], subject: 'Test', text: 'Hi' });
+      expect((sent[0] as any).to).toEqual(['good@x.com']);
+    });
+
+    it('throws when all recipients are invalid', async () => {
+      const { service } = makeService();
+      await expect(service.send({ to: 'not-valid', subject: 'X', text: 'y' })).rejects.toThrow(
+        'No valid recipients'
+      );
+    });
+  });
+
+  describe('template helpers', () => {
+    it('sendWelcome uses welcome template and sets subject', async () => {
+      const { service, sent } = makeService();
+      await service.sendWelcome('u@x.com', 'Alice', { dashboardUrl: 'https://app.io', docsUrl: 'https://docs.io' });
+      expect((sent[0] as any).subject).toContain('Alice');
+      expect((sent[0] as any).html).toContain('Alice');
+    });
+
+    it('sendPasswordReset includes reset URL in rendered HTML', async () => {
+      const { service, sent } = makeService();
+      await service.sendPasswordReset('u@x.com', 'Bob', 'https://reset.link/token');
+      expect((sent[0] as any).html).toContain('https://reset.link/token');
+    });
+
+    it('sendVerification includes verification code', async () => {
+      const { service, sent } = makeService();
+      await service.sendVerification('u@x.com', 'Carol', 'https://verify.link', '123456');
+      expect((sent[0] as any).html).toContain('123456');
+    });
+
+    it('sendNotification sets type badge', async () => {
+      const { service, sent } = makeService();
+      await service.sendNotification('u@x.com', 'Dave', 'Alert!', 'Something happened', {
+        type: 'warning',
+      });
+      expect((sent[0] as any).html).toContain('warning');
+    });
+  });
+
+  describe('getSentLog()', () => {
+    it('records each sent email', async () => {
+      const { service } = makeService();
+      await service.send({ to: 'a@x.com', subject: 'S1', text: 't' });
+      await service.send({ to: 'b@x.com', subject: 'S2', text: 't' });
+      const log = service.getSentLog();
+      expect(log).toHaveLength(2);
+      expect(log[0].subject).toBe('S1');
+      expect(log[1].subject).toBe('S2');
+    });
+
+    it('returns a copy, not a reference', async () => {
+      const { service } = makeService();
+      await service.send({ to: 'a@x.com', subject: 'X', text: 't' });
+      const log1 = service.getSentLog();
+      log1.push({ messageId: 'fake', to: [], subject: '', sentAt: new Date(), provider: '' });
+      expect(service.getSentLog()).toHaveLength(1);
+    });
+  });
+
+  describe('verifyConnection()', () => {
+    it('returns true when transporter verify succeeds', async () => {
+      const { service } = makeService();
+      expect(await service.verifyConnection()).toBe(true);
+    });
+
+    it('returns false when transporter verify throws', async () => {
+      const { service } = makeService();
+      // @ts-expect-error
+      service.transporter.verify = async () => { throw new Error('refused'); };
+      expect(await service.verifyConnection()).toBe(false);
+    });
+  });
+});

--- a/backend/src/services/emailService.ts
+++ b/backend/src/services/emailService.ts
@@ -1,0 +1,252 @@
+import nodemailer from 'nodemailer';
+import type { Transporter, SendMailOptions } from 'nodemailer';
+import * as fs from 'fs';
+import * as path from 'path';
+import { getEmailConfig, type EmailConfig } from '../config/email';
+import { interpolate, isValidEmail, formatAddress } from '../utils/emailUtils';
+import { log } from '../utils/logger';
+
+export interface SendEmailOptions {
+  to: string | string[];
+  subject: string;
+  html?: string;
+  text?: string;
+  template?: EmailTemplate;
+  templateVars?: Record<string, string>;
+  replyTo?: string;
+  cc?: string[];
+  bcc?: string[];
+  attachments?: Array<{ filename: string; content: Buffer | string; contentType?: string }>;
+}
+
+export type EmailTemplate =
+  | 'welcome'
+  | 'password-reset'
+  | 'account-verification'
+  | 'notification';
+
+export interface EmailResult {
+  messageId: string;
+  accepted: string[];
+  rejected: string[];
+}
+
+export interface EmailTrackingRecord {
+  messageId: string;
+  to: string[];
+  subject: string;
+  sentAt: Date;
+  provider: string;
+}
+
+const TEMPLATES_DIR = path.join(__dirname, '..', 'templates');
+
+export class EmailService {
+  private transporter: Transporter;
+  private config: EmailConfig;
+  private sentLog: EmailTrackingRecord[] = [];
+
+  constructor(config?: EmailConfig) {
+    this.config = config ?? getEmailConfig();
+    this.transporter = this.createTransporter(this.config);
+  }
+
+  private createTransporter(config: EmailConfig): Transporter {
+    switch (config.provider) {
+      case 'sendgrid':
+        return nodemailer.createTransport({
+          host: 'smtp.sendgrid.net',
+          port: 587,
+          auth: { user: 'apikey', pass: config.sendgridApiKey },
+        });
+
+      case 'mailgun':
+        return nodemailer.createTransport({
+          host: `smtp.mailgun.org`,
+          port: 587,
+          auth: {
+            user: `postmaster@${config.mailgun?.domain}`,
+            pass: config.mailgun?.apiKey,
+          },
+        });
+
+      case 'ses':
+        return nodemailer.createTransport({
+          host: `email-smtp.${config.ses?.region}.amazonaws.com`,
+          port: 587,
+          auth: {
+            user: config.ses?.accessKeyId,
+            pass: config.ses?.secretAccessKey,
+          },
+        });
+
+      case 'smtp':
+      default:
+        return nodemailer.createTransport({
+          host: config.smtp?.host ?? 'localhost',
+          port: config.smtp?.port ?? 587,
+          secure: config.smtp?.secure ?? false,
+          auth:
+            config.smtp?.user
+              ? { user: config.smtp.user, pass: config.smtp.pass }
+              : undefined,
+        });
+    }
+  }
+
+  private loadTemplate(name: EmailTemplate): string {
+    const filePath = path.join(TEMPLATES_DIR, `${name}.html`);
+    return fs.readFileSync(filePath, 'utf-8');
+  }
+
+  private buildHtml(options: SendEmailOptions): string | undefined {
+    if (options.html) return options.html;
+    if (!options.template) return undefined;
+
+    const raw = this.loadTemplate(options.template);
+    const vars = {
+      year: String(new Date().getFullYear()),
+      ...options.templateVars,
+    };
+    return interpolate(raw, vars);
+  }
+
+  private normaliseRecipients(to: string | string[]): string[] {
+    return (Array.isArray(to) ? to : [to]).filter((addr) => {
+      if (!isValidEmail(addr)) {
+        log.warn('[email] skipping invalid address', { address: addr });
+        return false;
+      }
+      return true;
+    });
+  }
+
+  async send(options: SendEmailOptions): Promise<EmailResult> {
+    const recipients = this.normaliseRecipients(options.to);
+    if (recipients.length === 0) {
+      throw new Error('No valid recipients provided');
+    }
+
+    const from = formatAddress(this.config.fromName, this.config.from);
+    const html = this.buildHtml(options);
+
+    const mailOptions: SendMailOptions = {
+      from,
+      to: recipients,
+      subject: options.subject,
+      html,
+      text: options.text,
+      replyTo: options.replyTo ?? this.config.replyTo,
+      cc: options.cc,
+      bcc: options.bcc,
+      attachments: options.attachments,
+    };
+
+    log.info('[email] sending', {
+      to: recipients,
+      subject: options.subject,
+      provider: this.config.provider,
+      template: options.template,
+    });
+
+    const info = await this.transporter.sendMail(mailOptions);
+
+    const record: EmailTrackingRecord = {
+      messageId: info.messageId,
+      to: recipients,
+      subject: options.subject,
+      sentAt: new Date(),
+      provider: this.config.provider,
+    };
+    this.sentLog.push(record);
+
+    log.info('[email] sent', { messageId: info.messageId, accepted: info.accepted });
+
+    return {
+      messageId: info.messageId,
+      accepted: info.accepted as string[],
+      rejected: info.rejected as string[],
+    };
+  }
+
+  async sendWelcome(to: string, name: string, vars: Record<string, string> = {}): Promise<EmailResult> {
+    return this.send({
+      to,
+      subject: `Welcome to ChenAIKit, ${name}!`,
+      template: 'welcome',
+      templateVars: { name, dashboardUrl: vars.dashboardUrl ?? '', docsUrl: vars.docsUrl ?? '', ...vars },
+    });
+  }
+
+  async sendPasswordReset(to: string, name: string, resetUrl: string, expiresIn = '1 hour'): Promise<EmailResult> {
+    return this.send({
+      to,
+      subject: 'Reset your ChenAIKit password',
+      template: 'password-reset',
+      templateVars: { name, resetUrl, expiresIn },
+    });
+  }
+
+  async sendVerification(
+    to: string,
+    name: string,
+    verifyUrl: string,
+    verificationCode: string,
+    expiresIn = '24 hours'
+  ): Promise<EmailResult> {
+    return this.send({
+      to,
+      subject: 'Verify your ChenAIKit account',
+      template: 'account-verification',
+      templateVars: { name, verifyUrl, verificationCode, expiresIn },
+    });
+  }
+
+  async sendNotification(
+    to: string,
+    name: string,
+    subject: string,
+    message: string,
+    opts: { type?: string; actionUrl?: string; actionLabel?: string; unsubscribeUrl?: string } = {}
+  ): Promise<EmailResult> {
+    return this.send({
+      to,
+      subject,
+      template: 'notification',
+      templateVars: {
+        name,
+        subject,
+        message,
+        type: opts.type ?? 'info',
+        actionUrl: opts.actionUrl ?? '',
+        actionLabel: opts.actionLabel ?? 'View Details',
+        unsubscribeUrl: opts.unsubscribeUrl ?? '#',
+      },
+    });
+  }
+
+  /** Returns a copy of the in-memory sent log (useful in tests and admin views). */
+  getSentLog(): EmailTrackingRecord[] {
+    return [...this.sentLog];
+  }
+
+  async verifyConnection(): Promise<boolean> {
+    try {
+      await this.transporter.verify();
+      log.info('[email] transporter connection verified');
+      return true;
+    } catch (err) {
+      log.error('[email] transporter connection failed', err as Error);
+      return false;
+    }
+  }
+}
+
+let instance: EmailService | null = null;
+
+export function getEmailService(): EmailService {
+  if (!instance) {
+    instance = new EmailService();
+  }
+  return instance;
+}

--- a/backend/src/templates/account-verification.html
+++ b/backend/src/templates/account-verification.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Verify Your Account</title>
+  <style>
+    body { font-family: Arial, sans-serif; background: #f4f4f4; margin: 0; padding: 0; }
+    .container { max-width: 600px; margin: 40px auto; background: #fff; border-radius: 8px; overflow: hidden; }
+    .header { background: #1a1a2e; padding: 32px; text-align: center; }
+    .header h1 { color: #fff; margin: 0; font-size: 24px; }
+    .body { padding: 32px; color: #333; line-height: 1.6; }
+    .btn { display: inline-block; padding: 12px 28px; background: #27ae60; color: #fff;
+           text-decoration: none; border-radius: 6px; font-weight: bold; margin-top: 16px; }
+    .code-block { background: #f0f0f0; border-radius: 6px; padding: 16px; text-align: center;
+                  font-size: 28px; font-weight: bold; letter-spacing: 8px; color: #1a1a2e; margin: 24px 0; }
+    .footer { padding: 16px 32px; background: #f9f9f9; color: #888; font-size: 12px; text-align: center; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="header"><h1>Verify Your Account ✅</h1></div>
+    <div class="body">
+      <p>Hi {{name}},</p>
+      <p>Thanks for signing up! Please verify your email address to activate your ChenAIKit account.</p>
+      <p>Use the verification code below or click the button:</p>
+      <div class="code-block">{{verificationCode}}</div>
+      <a class="btn" href="{{verifyUrl}}">Verify Email Address</a>
+      <p style="margin-top: 24px; font-size: 14px; color: #777;">This code expires in {{expiresIn}}. If you didn't create an account, please ignore this email.</p>
+    </div>
+    <div class="footer">© {{year}} ChenAIKit. This is an automated message — please do not reply.</div>
+  </div>
+</body>
+</html>

--- a/backend/src/templates/notification.html
+++ b/backend/src/templates/notification.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{{subject}}</title>
+  <style>
+    body { font-family: Arial, sans-serif; background: #f4f4f4; margin: 0; padding: 0; }
+    .container { max-width: 600px; margin: 40px auto; background: #fff; border-radius: 8px; overflow: hidden; }
+    .header { background: #1a1a2e; padding: 32px; text-align: center; }
+    .header h1 { color: #fff; margin: 0; font-size: 22px; }
+    .badge { display: inline-block; padding: 4px 12px; border-radius: 20px; font-size: 12px;
+             font-weight: bold; text-transform: uppercase; margin-bottom: 8px; }
+    .badge-info    { background: #3498db; color: #fff; }
+    .badge-warning { background: #f39c12; color: #fff; }
+    .badge-success { background: #27ae60; color: #fff; }
+    .badge-alert   { background: #e74c3c; color: #fff; }
+    .body { padding: 32px; color: #333; line-height: 1.6; }
+    .btn { display: inline-block; padding: 12px 28px; background: #6c63ff; color: #fff;
+           text-decoration: none; border-radius: 6px; font-weight: bold; margin-top: 16px; }
+    .footer { padding: 16px 32px; background: #f9f9f9; color: #888; font-size: 12px; text-align: center; }
+    .unsubscribe { margin-top: 8px; }
+    .unsubscribe a { color: #aaa; font-size: 11px; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="header">
+      <div class="badge badge-{{type}}">{{type}}</div>
+      <h1>{{subject}}</h1>
+    </div>
+    <div class="body">
+      <p>Hi {{name}},</p>
+      <p>{{message}}</p>
+      {{#if actionUrl}}
+      <a class="btn" href="{{actionUrl}}">{{actionLabel}}</a>
+      {{/if}}
+    </div>
+    <div class="footer">
+      © {{year}} ChenAIKit.
+      <div class="unsubscribe">
+        <a href="{{unsubscribeUrl}}">Unsubscribe from notifications</a>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/backend/src/templates/password-reset.html
+++ b/backend/src/templates/password-reset.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Reset Your Password</title>
+  <style>
+    body { font-family: Arial, sans-serif; background: #f4f4f4; margin: 0; padding: 0; }
+    .container { max-width: 600px; margin: 40px auto; background: #fff; border-radius: 8px; overflow: hidden; }
+    .header { background: #1a1a2e; padding: 32px; text-align: center; }
+    .header h1 { color: #fff; margin: 0; font-size: 24px; }
+    .body { padding: 32px; color: #333; line-height: 1.6; }
+    .btn { display: inline-block; padding: 12px 28px; background: #e74c3c; color: #fff;
+           text-decoration: none; border-radius: 6px; font-weight: bold; margin-top: 16px; }
+    .warning { background: #fff8e1; border-left: 4px solid #ffc107; padding: 12px 16px;
+               margin-top: 24px; border-radius: 4px; font-size: 14px; color: #555; }
+    .footer { padding: 16px 32px; background: #f9f9f9; color: #888; font-size: 12px; text-align: center; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="header"><h1>Password Reset Request</h1></div>
+    <div class="body">
+      <p>Hi {{name}},</p>
+      <p>We received a request to reset the password for your ChenAIKit account. Click the button below to choose a new password:</p>
+      <a class="btn" href="{{resetUrl}}">Reset Password</a>
+      <div class="warning">
+        ⚠️ This link expires in <strong>{{expiresIn}}</strong>. If you did not request a password reset, you can safely ignore this email.
+      </div>
+    </div>
+    <div class="footer">© {{year}} ChenAIKit. For security reasons, never share this link with anyone.</div>
+  </div>
+</body>
+</html>

--- a/backend/src/templates/welcome.html
+++ b/backend/src/templates/welcome.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Welcome to ChenAIKit</title>
+  <style>
+    body { font-family: Arial, sans-serif; background: #f4f4f4; margin: 0; padding: 0; }
+    .container { max-width: 600px; margin: 40px auto; background: #fff; border-radius: 8px; overflow: hidden; }
+    .header { background: #1a1a2e; padding: 32px; text-align: center; }
+    .header h1 { color: #fff; margin: 0; font-size: 24px; }
+    .body { padding: 32px; color: #333; line-height: 1.6; }
+    .btn { display: inline-block; padding: 12px 28px; background: #6c63ff; color: #fff;
+           text-decoration: none; border-radius: 6px; font-weight: bold; margin-top: 16px; }
+    .footer { padding: 16px 32px; background: #f9f9f9; color: #888; font-size: 12px; text-align: center; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="header"><h1>Welcome to ChenAIKit 🎉</h1></div>
+    <div class="body">
+      <p>Hi {{name}},</p>
+      <p>We're excited to have you on board! ChenAIKit gives you powerful AI tools to build smarter applications faster.</p>
+      <p>Get started by exploring the dashboard:</p>
+      <a class="btn" href="{{dashboardUrl}}">Go to Dashboard</a>
+      <p style="margin-top: 24px;">If you have any questions, reply to this email or check our <a href="{{docsUrl}}">documentation</a>.</p>
+    </div>
+    <div class="footer">© {{year}} ChenAIKit. You received this email because you created an account.</div>
+  </div>
+</body>
+</html>

--- a/backend/src/utils/emailUtils.ts
+++ b/backend/src/utils/emailUtils.ts
@@ -1,0 +1,46 @@
+/**
+ * Lightweight email utilities — formatting, sanitisation, and address helpers.
+ */
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function isValidEmail(address: string): boolean {
+  return EMAIL_RE.test(address.trim());
+}
+
+/**
+ * Format a display name + address pair, e.g. `"Alice" <alice@example.com>`.
+ */
+export function formatAddress(name: string, address: string): string {
+  const clean = name.replace(/"/g, '\\"');
+  return `"${clean}" <${address}>`;
+}
+
+/**
+ * Very small HTML sanitiser: strips script tags and on* attributes so
+ * plain-text values injected into templates cannot XSS.
+ */
+export function sanitizeHtml(html: string): string {
+  return html
+    .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+    .replace(/\son\w+\s*=\s*["'][^"']*["']/gi, '');
+}
+
+/**
+ * Interpolate `{{key}}` placeholders in a template string.
+ */
+export function interpolate(template: string, vars: Record<string, string>): string {
+  return template.replace(/\{\{(\w+)\}\}/g, (_, key) =>
+    Object.prototype.hasOwnProperty.call(vars, key) ? vars[key] : `{{${key}}}`
+  );
+}
+
+/**
+ * Convert plain text to a minimal HTML paragraph block for multi-part emails.
+ */
+export function textToHtml(text: string): string {
+  return text
+    .split('\n')
+    .map((line) => `<p>${sanitizeHtml(line)}</p>`)
+    .join('\n');
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,7 +86,7 @@ importers:
         version: 7.2.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@20.19.43)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@20.19.43)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.43)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -141,6 +141,9 @@ importers:
       jsonwebtoken:
         specifier: ^9.0.3
         version: 9.0.3
+      nodemailer:
+        specifier: ^6.9.0
+        version: 6.10.1
       prom-client:
         specifier: ^15.1.3
         version: 15.1.3
@@ -190,6 +193,9 @@ importers:
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.43
+      '@types/nodemailer':
+        specifier: ^6.4.0
+        version: 6.4.24
       '@types/uuid':
         specifier: ^9.0.7
         version: 9.0.8
@@ -522,7 +528,7 @@ importers:
         version: 29.7.0(@types/node@20.19.43)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.43)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.6
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@20.19.43)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@20.19.43)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.43)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -541,7 +547,7 @@ importers:
         version: 29.7.0(@types/node@20.19.43)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.43)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.0.0
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@20.19.43)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@20.19.43)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.43)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -560,7 +566,7 @@ importers:
         version: 29.7.0(@types/node@20.19.43)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.43)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.0.0
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@20.19.43)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@20.19.43)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.43)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -588,7 +594,7 @@ importers:
         version: 29.7.0(@types/node@20.19.43)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.43)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@20.19.43)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@20.19.43)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.43)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -3402,6 +3408,9 @@ packages:
 
   '@types/node@20.19.43':
     resolution: {integrity: sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==}
+
+  '@types/nodemailer@6.4.24':
+    resolution: {integrity: sha512-Ww4u0rT9wQNXh4JiQaIwx3QWdcOFXzOjQA2zc+jtFYNmQiT4mIUqcDin51bDFdkzKubFnQCZNK7FIHlPKQ/q9w==}
 
   '@types/oracledb@6.5.2':
     resolution: {integrity: sha512-kK1eBS/Adeyis+3OlBDMeQQuasIDLUYXsi2T15ccNJ0iyUpQ4xDF7svFu3+bGVrI0CMBUclPciz+lsQR3JX3TQ==}
@@ -7373,6 +7382,10 @@ packages:
   node-releases@2.0.47:
     resolution: {integrity: sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==}
     engines: {node: '>=18'}
+
+  nodemailer@6.10.1:
+    resolution: {integrity: sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==}
+    engines: {node: '>=6.0.0'}
 
   nopt@5.0.0:
     resolution: {integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==}
@@ -13778,6 +13791,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/nodemailer@6.4.24':
+    dependencies:
+      '@types/node': 20.19.43
+
   '@types/oracledb@6.5.2':
     dependencies:
       '@types/node': 20.19.43
@@ -18869,6 +18886,8 @@ snapshots:
 
   node-releases@2.0.47: {}
 
+  nodemailer@6.10.1: {}
+
   nopt@5.0.0:
     dependencies:
       abbrev: 1.1.1
@@ -21127,7 +21146,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@20.19.43)(babel-plugin-macros@3.1.0))(typescript@5.9.3):
+  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@20.19.43)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.43)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0


### PR DESCRIPTION
## Summary

Closes #176

Implements a complete email notification system for the ChenAIKit backend.

### What's included

- **Multi-provider transport** — SMTP (default), SendGrid, Mailgun, and AWS SES, all configured via environment variables. Switch providers with `EMAIL_PROVIDER=` — no code changes needed.
- **`EmailService`** — typed class with convenience methods: `sendWelcome`, `sendPasswordReset`, `sendVerification`, `sendNotification`, plus a generic `send()` for custom payloads.
- **HTML templates** — four responsive templates: welcome, password-reset, account-verification, and notification (with info/warning/success/alert badge variants).
- **Bull job queue** (`jobs/sendEmail.ts`) — `enqueueEmail()` drops emails into a Redis-backed queue with exponential backoff retries. Concurrency and retry counts are env-configurable.
- **`emailUtils.ts`** — `isValidEmail`, `formatAddress`, `interpolate`, `sanitizeHtml`, `textToHtml` helpers.
- **12 unit tests** — covers send paths, template rendering, invalid recipient filtering, sent-log immutability, and connection verification.
- **`.env.example`** — documents all new env vars (`EMAIL_*`, `SMTP_*`, `SENDGRID_*`, `MAILGUN_*`, `AWS_SES_*`, `EMAIL_QUEUE_*`).

### Files added / changed

| File | Change |
|---|---|
| `backend/src/config/email.ts` | Zod-validated email config |
| `backend/src/services/emailService.ts` | Core `EmailService` class |
| `backend/src/jobs/sendEmail.ts` | Bull queue worker |
| `backend/src/templates/*.html` | 4 HTML email templates |
| `backend/src/utils/emailUtils.ts` | Address/template utilities |
| `backend/src/services/__tests__/emailService.test.ts` | Unit tests |
| `backend/package.json` | Add `nodemailer` + `@types/nodemailer` |
| `backend/.env.example` | Document all new env vars |

## Test plan

- [ ] `pnpm test` in `backend/` — all 12 email tests pass
- [ ] Set `EMAIL_PROVIDER=smtp` with a local Mailhog instance and call `sendWelcome` — email appears in Mailhog UI
- [ ] Set `EMAIL_PROVIDER=sendgrid` with a real API key — delivery confirmed in SendGrid activity feed
- [ ] Missing/invalid `EMAIL_FROM` throws a Zod validation error on startup
- [ ] `enqueueEmail()` adds a job visible in Bull Board / Redis

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive email delivery system supporting multiple providers (SMTP, SendGrid, Mailgun, AWS SES).
  * Integrated asynchronous email queue for reliable, resilient message delivery with retry capabilities.
  * Added pre-built email templates for user onboarding, password reset, account verification, and notifications.

* **Chores**
  * Added required email delivery dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->