### PR TITLE
Add database backup and restore with encryption and S3 support

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -59,6 +59,7 @@
     "jest": "^29.0.0",
     "prisma": "^5.0.0",
     "ts-node": "^10.9.0",
+    "@types/better-sqlite3": "^7.6.0",
     "@types/nodemailer": "^6.4.0",
     "typescript": "^5.0.0"
   }

--- a/backend/src/__tests__/backupService.test.ts
+++ b/backend/src/__tests__/backupService.test.ts
@@ -16,7 +16,7 @@ const testEncKey = crypto.randomBytes(32).toString('hex')
 // Mock backupConfig before any module that imports it is loaded
 // -----------------------------------------------------------------------
 jest.mock('../utils/logger', () => ({
-  logger: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+  winstonLogger: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
 }))
 
 jest.mock('../config/backup', () => ({

--- a/backend/src/__tests__/backupService.test.ts
+++ b/backend/src/__tests__/backupService.test.ts
@@ -1,0 +1,184 @@
+import path from 'node:path'
+import fs from 'node:fs'
+import os from 'node:os'
+import crypto from 'node:crypto'
+import Database from 'better-sqlite3'
+
+// -----------------------------------------------------------------------
+// Temporary filesystem space for each test run
+// -----------------------------------------------------------------------
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'chenaikit-backup-test-'))
+const testDbPath = path.join(tmpDir, 'test.db')
+const testBackupDir = path.join(tmpDir, 'backups')
+const testEncKey = crypto.randomBytes(32).toString('hex')
+
+// -----------------------------------------------------------------------
+// Mock backupConfig before any module that imports it is loaded
+// -----------------------------------------------------------------------
+jest.mock('../utils/logger', () => ({
+  logger: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+}))
+
+jest.mock('../config/backup', () => ({
+  backupConfig: {
+    dir: testBackupDir,
+    encryptionKey: testEncKey,
+    retentionCount: 3,
+    s3Region: 'us-east-1',
+    s3Bucket: '',
+    s3Prefix: 'chenaikit/db/',
+    awsAccessKeyId: '',
+    awsSecretAccessKey: '',
+    dbPath: testDbPath,
+  },
+}))
+
+// Import after the mock is in place
+import { BackupService } from '../services/backupService'
+import { backupConfig } from '../config/backup'
+
+// -----------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------
+
+function createTestDb(dbPath: string): void {
+  const db = new Database(dbPath)
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY, name TEXT);
+    INSERT INTO users (name) VALUES ('Alice'), ('Bob');
+  `)
+  db.close()
+}
+
+function countUsers(dbPath: string): number {
+  const db = new Database(dbPath, { readonly: true })
+  const result = db.prepare('SELECT COUNT(*) as cnt FROM users').get() as { cnt: number }
+  db.close()
+  return result.cnt
+}
+
+// -----------------------------------------------------------------------
+// Test lifecycle
+// -----------------------------------------------------------------------
+
+beforeEach(() => {
+  createTestDb(testDbPath)
+  fs.mkdirSync(testBackupDir, { recursive: true })
+})
+
+afterEach(() => {
+  fs.rmSync(testDbPath, { force: true })
+  fs.rmSync(testBackupDir, { recursive: true, force: true })
+})
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+// -----------------------------------------------------------------------
+// BackupService.createBackup
+// -----------------------------------------------------------------------
+
+describe('BackupService.createBackup', () => {
+  it('creates an encrypted gzip backup file in the backup directory', async () => {
+    const service = new BackupService()
+    const result = await service.createBackup()
+
+    expect(result.filename).toMatch(/^backup-.+\.enc\.gz$/)
+    expect(result.encrypted).toBe(true)
+    expect(result.uploadedToS3).toBe(false)
+    expect(result.sizeBytes).toBeGreaterThan(0)
+    expect(fs.existsSync(result.localPath)).toBe(true)
+  })
+
+  it('backup contains a valid restorable snapshot of the database', async () => {
+    const service = new BackupService()
+    const result = await service.createBackup()
+
+    // Wipe the live database to simulate data loss
+    const db = new Database(testDbPath)
+    db.exec('DELETE FROM users')
+    db.close()
+    expect(countUsers(testDbPath)).toBe(0)
+
+    await service.restore(result.localPath)
+
+    expect(countUsers(testDbPath)).toBe(2)
+  })
+
+  it('prunes oldest backups when retention limit is exceeded', async () => {
+    const service = new BackupService()
+
+    for (let i = 0; i < 5; i++) {
+      await service.createBackup()
+      // Timestamps must differ so filenames are unique
+      await new Promise((r) => setTimeout(r, 20))
+    }
+
+    const files = fs.readdirSync(testBackupDir)
+    expect(files).toHaveLength(3)  // retention = 3
+  })
+})
+
+// -----------------------------------------------------------------------
+// BackupService.restore
+// -----------------------------------------------------------------------
+
+describe('BackupService.restore', () => {
+  it('restores from a local encrypted backup file', async () => {
+    const service = new BackupService()
+    const { localPath } = await service.createBackup()
+
+    const db = new Database(testDbPath)
+    db.exec('DROP TABLE users')
+    db.close()
+
+    await service.restore(localPath)
+    expect(countUsers(testDbPath)).toBe(2)
+  })
+
+  it('throws when restoring an encrypted backup without the encryption key', async () => {
+    const service = new BackupService()
+    const { localPath } = await service.createBackup()
+
+    const originalKey = backupConfig.encryptionKey
+    Object.assign(backupConfig, { encryptionKey: '' })
+
+    await expect(service.restore(localPath)).rejects.toThrow(/encryption/i)
+
+    Object.assign(backupConfig, { encryptionKey: originalKey })
+  })
+
+  it('throws when the backup source file does not exist', async () => {
+    const service = new BackupService()
+    await expect(service.restore('/nonexistent/backup.enc.gz')).rejects.toThrow()
+  })
+})
+
+// -----------------------------------------------------------------------
+// BackupService.listLocalBackups
+// -----------------------------------------------------------------------
+
+describe('BackupService.listLocalBackups', () => {
+  it('returns backup files sorted newest-first', async () => {
+    const service = new BackupService()
+
+    await service.createBackup()
+    await new Promise((r) => setTimeout(r, 20))
+    await service.createBackup()
+
+    const list = await service.listLocalBackups()
+    expect(list).toHaveLength(2)
+    expect(list[0].createdAt.getTime()).toBeGreaterThanOrEqual(list[1].createdAt.getTime())
+    for (const entry of list) {
+      expect(entry.sizeBytes).toBeGreaterThan(0)
+      expect(entry.filename).toBeTruthy()
+    }
+  })
+
+  it('returns an empty array when no backup files exist', async () => {
+    fs.rmSync(testBackupDir, { recursive: true, force: true })
+    const service = new BackupService()
+    await expect(service.listLocalBackups()).resolves.toEqual([])
+  })
+})

--- a/backend/src/config/backup.ts
+++ b/backend/src/config/backup.ts
@@ -11,7 +11,10 @@ export const backupConfig = {
   schedule: process.env.BACKUP_SCHEDULE ?? '0 2 * * *',
 
   /** How many local backup files to retain before pruning the oldest. */
-  retentionCount: parseInt(process.env.BACKUP_RETENTION_COUNT ?? '14', 10),
+  retentionCount: (() => {
+    const parsed = parseInt(process.env.BACKUP_RETENTION_COUNT ?? '14', 10)
+    return Number.isNaN(parsed) || parsed < 1 ? 14 : parsed
+  })(),
 
   /** AWS region for S3 uploads. Required when S3_BUCKET is set. */
   s3Region: process.env.AWS_REGION ?? 'us-east-1',
@@ -31,6 +34,7 @@ export const backupConfig = {
   /** Path to the SQLite database file. Derived from DATABASE_URL by default. */
   get dbPath(): string {
     const url = process.env.DATABASE_URL ?? ''
+    if (!url) throw new Error('DATABASE_URL environment variable is required')
     // SQLite URLs: "file:./dev.db" or "/absolute/path/to/app.db"
     const match = url.match(/^file:(.+)$/)
     return match ? path.resolve(match[1]) : path.resolve(url)

--- a/backend/src/config/backup.ts
+++ b/backend/src/config/backup.ts
@@ -1,0 +1,40 @@
+import path from 'node:path'
+
+export const backupConfig = {
+  /** Directory where local backup files are stored. */
+  dir: process.env.BACKUP_DIR ?? path.resolve(process.cwd(), 'backups'),
+
+  /** AES-256-GCM encryption key as a 64-char hex string (32 bytes). Set to enable encryption. */
+  encryptionKey: process.env.BACKUP_ENCRYPTION_KEY ?? '',
+
+  /** Cron-style schedule for automated backups (default: every day at 02:00). */
+  schedule: process.env.BACKUP_SCHEDULE ?? '0 2 * * *',
+
+  /** How many local backup files to retain before pruning the oldest. */
+  retentionCount: parseInt(process.env.BACKUP_RETENTION_COUNT ?? '14', 10),
+
+  /** AWS region for S3 uploads. Required when S3_BUCKET is set. */
+  s3Region: process.env.AWS_REGION ?? 'us-east-1',
+
+  /** S3 bucket name for off-site backup storage. Leave blank to skip S3 upload. */
+  s3Bucket: process.env.S3_BUCKET ?? '',
+
+  /** S3 key prefix for backup objects (e.g. "chenaikit/db/"). */
+  s3Prefix: process.env.S3_BACKUP_PREFIX ?? 'chenaikit/db/',
+
+  /** AWS access key ID. Required when S3_BUCKET is set. */
+  awsAccessKeyId: process.env.AWS_ACCESS_KEY_ID ?? '',
+
+  /** AWS secret access key. Required when S3_BUCKET is set. */
+  awsSecretAccessKey: process.env.AWS_SECRET_ACCESS_KEY ?? '',
+
+  /** Path to the SQLite database file. Derived from DATABASE_URL by default. */
+  get dbPath(): string {
+    const url = process.env.DATABASE_URL ?? ''
+    // SQLite URLs: "file:./dev.db" or "/absolute/path/to/app.db"
+    const match = url.match(/^file:(.+)$/)
+    return match ? path.resolve(match[1]) : path.resolve(url)
+  },
+}
+
+export type BackupConfig = typeof backupConfig

--- a/backend/src/jobs/backupJob.ts
+++ b/backend/src/jobs/backupJob.ts
@@ -13,6 +13,11 @@ let backupQueue: Queue.Queue | null = null
  * Call once at application startup when Redis is available.
  */
 export function initBackupScheduler(redisUrl: string): void {
+  if (backupQueue) {
+    logger.warn('Backup scheduler already initialised, skipping')
+    return
+  }
+
   backupQueue = new Queue(QUEUE_NAME, redisUrl, {
     defaultJobOptions: {
       attempts: 3,

--- a/backend/src/jobs/backupJob.ts
+++ b/backend/src/jobs/backupJob.ts
@@ -1,7 +1,7 @@
 import Queue from 'bull'
 import { backupService } from '../services/backupService'
 import { backupConfig } from '../config/backup'
-import { logger } from '../utils/logger'
+import { winstonLogger as logger } from '../utils/logger'
 
 const QUEUE_NAME = 'database-backup'
 

--- a/backend/src/jobs/backupJob.ts
+++ b/backend/src/jobs/backupJob.ts
@@ -1,0 +1,73 @@
+import Queue from 'bull'
+import { backupService } from '../services/backupService'
+import { backupConfig } from '../config/backup'
+import { logger } from '../utils/logger'
+
+const QUEUE_NAME = 'database-backup'
+
+let backupQueue: Queue.Queue | null = null
+
+/**
+ * Initialise the backup job queue and register the recurring schedule.
+ *
+ * Call once at application startup when Redis is available.
+ */
+export function initBackupScheduler(redisUrl: string): void {
+  backupQueue = new Queue(QUEUE_NAME, redisUrl, {
+    defaultJobOptions: {
+      attempts: 3,
+      backoff: { type: 'exponential', delay: 5000 },
+      removeOnComplete: true,
+      removeOnFail: false,
+    },
+  })
+
+  // Register the cron-style repeating backup job
+  backupQueue.add(
+    { type: 'scheduled' },
+    {
+      repeat: { cron: backupConfig.schedule },
+      jobId: 'backup-scheduled',
+    },
+  )
+
+  backupQueue.process(1, async (job) => {
+    logger.info('Running scheduled database backup', { jobId: job.id })
+    try {
+      const result = await backupService.createBackup()
+      logger.info('Scheduled backup completed', {
+        filename: result.filename,
+        sizeBytes: result.sizeBytes,
+        uploadedToS3: result.uploadedToS3,
+        durationMs: result.durationMs,
+      })
+      return result
+    } catch (err) {
+      logger.error('Scheduled backup failed', { error: err instanceof Error ? err.message : String(err) })
+      throw err
+    }
+  })
+
+  backupQueue.on('failed', (job, err) => {
+    logger.error('Backup job failed', { jobId: job.id, error: err.message, attempts: job.attemptsMade })
+  })
+
+  logger.info('Backup scheduler initialised', { schedule: backupConfig.schedule })
+}
+
+/**
+ * Enqueue an immediate (manual) backup job.
+ */
+export async function triggerManualBackup(): Promise<string> {
+  if (!backupQueue) throw new Error('Backup scheduler is not initialised')
+  const job = await backupQueue.add({ type: 'manual' }, { removeOnComplete: true })
+  logger.info('Manual backup job enqueued', { jobId: job.id })
+  return String(job.id)
+}
+
+export async function closeBackupScheduler(): Promise<void> {
+  if (backupQueue) {
+    await backupQueue.close()
+    backupQueue = null
+  }
+}

--- a/backend/src/scripts/backup.ts
+++ b/backend/src/scripts/backup.ts
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+/**
+ * Manual backup CLI
+ *
+ * Usage:
+ *   npx ts-node src/scripts/backup.ts
+ *   node dist/scripts/backup.js
+ *
+ * Environment variables:
+ *   DATABASE_URL              SQLite database file URL (e.g. file:./dev.db)
+ *   BACKUP_DIR                Directory for local backup files (default: ./backups)
+ *   BACKUP_ENCRYPTION_KEY     64-char hex key for AES-256-GCM encryption (optional)
+ *   S3_BUCKET                 S3 bucket name for off-site storage (optional)
+ *   S3_BACKUP_PREFIX          S3 key prefix (default: chenaikit/db/)
+ *   AWS_REGION                AWS region (default: us-east-1)
+ *   AWS_ACCESS_KEY_ID         AWS access key (required when S3_BUCKET is set)
+ *   AWS_SECRET_ACCESS_KEY     AWS secret key (required when S3_BUCKET is set)
+ *   BACKUP_RETENTION_COUNT    Local files to keep (default: 14)
+ */
+import 'dotenv/config'
+import { backupService } from '../services/backupService'
+
+async function main() {
+  console.log('Starting manual database backup...')
+  try {
+    const result = await backupService.createBackup()
+    console.log('Backup completed successfully:')
+    console.log(`  File:         ${result.localPath}`)
+    console.log(`  Size:         ${(result.sizeBytes / 1024).toFixed(1)} KB`)
+    console.log(`  Encrypted:    ${result.encrypted}`)
+    console.log(`  Uploaded S3:  ${result.uploadedToS3}`)
+    console.log(`  Duration:     ${result.durationMs}ms`)
+    process.exit(0)
+  } catch (err) {
+    console.error('Backup failed:', err instanceof Error ? err.message : String(err))
+    process.exit(1)
+  }
+}
+
+main()

--- a/backend/src/scripts/restore.ts
+++ b/backend/src/scripts/restore.ts
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+/**
+ * Database restore CLI
+ *
+ * Usage:
+ *   npx ts-node src/scripts/restore.ts <source>
+ *   node dist/scripts/restore.js <source>
+ *
+ * <source> is one of:
+ *   - An absolute or relative path to a local backup file
+ *   - An S3 key (e.g. "chenaikit/db/backup-2026-06-19T02-00-00Z.enc.gz")
+ *
+ * The script will:
+ *   1. Fetch the backup file (from disk or S3)
+ *   2. Decrypt it if BACKUP_ENCRYPTION_KEY is set and the filename contains ".enc."
+ *   3. Decompress the gzip archive
+ *   4. Verify SQLite integrity
+ *   5. Atomically replace the live database file
+ *
+ * WARNING: This will overwrite the current database. Ensure all application
+ * connections are closed before running in production.
+ */
+import 'dotenv/config'
+import { backupService } from '../services/backupService'
+
+async function main() {
+  const source = process.argv[2]
+
+  if (!source) {
+    console.error('Usage: restore <backup-file-or-s3-key>')
+    console.error('')
+    console.error('Examples:')
+    console.error('  restore ./backups/backup-2026-06-19T02-00-00Z.enc.gz')
+    console.error('  restore chenaikit/db/backup-2026-06-19T02-00-00Z.enc.gz  # S3 key')
+    process.exit(1)
+  }
+
+  console.log(`Restoring database from: ${source}`)
+  console.log('WARNING: This will overwrite the current database.')
+
+  // Give the operator a moment to abort in non-interactive environments
+  if (process.env.RESTORE_CONFIRM !== 'yes') {
+    console.log('Set RESTORE_CONFIRM=yes to skip this prompt.')
+    console.log('Proceeding in 3 seconds... Ctrl+C to abort.')
+    await new Promise((r) => setTimeout(r, 3000))
+  }
+
+  try {
+    const result = await backupService.restore(source)
+    console.log('Restore completed successfully:')
+    console.log(`  Source:    ${result.restoredFrom}`)
+    console.log(`  Duration:  ${result.durationMs}ms`)
+    process.exit(0)
+  } catch (err) {
+    console.error('Restore failed:', err instanceof Error ? err.message : String(err))
+    process.exit(1)
+  }
+}
+
+main()

--- a/backend/src/services/backupService.ts
+++ b/backend/src/services/backupService.ts
@@ -101,7 +101,8 @@ export class BackupService {
    */
   async restore(source: string): Promise<RestoreResult> {
     const start = Date.now()
-    const isS3Key = !path.isAbsolute(source) && !source.startsWith('.')
+    const isS3Key = source.startsWith('s3://')
+    const s3KeyPath = isS3Key ? source.slice(5) : source
 
     const tmpEncOrGz = path.join(os.tmpdir(), `chenaikit-restore-dl-${Date.now()}`)
     const tmpGz = path.join(os.tmpdir(), `chenaikit-restore-gz-${Date.now()}.gz`)
@@ -113,11 +114,11 @@ export class BackupService {
         if (!backupConfig.s3Bucket || !backupConfig.awsAccessKeyId) {
           throw new Error('S3_BUCKET and AWS credentials are required to restore from S3')
         }
-        logger.info('Downloading backup from S3', { key: source })
+        logger.info('Downloading backup from S3', { key: s3KeyPath })
         await downloadFromS3({
           destPath: tmpEncOrGz,
           bucket: backupConfig.s3Bucket,
-          key: source,
+          key: s3KeyPath,
           region: backupConfig.s3Region,
           accessKeyId: backupConfig.awsAccessKeyId,
           secretAccessKey: backupConfig.awsSecretAccessKey,
@@ -147,7 +148,9 @@ export class BackupService {
       this.verifySqlite(tmpRaw)
 
       // Step 5: atomically replace the live database
-      await fs.promises.copyFile(tmpRaw, backupConfig.dbPath)
+      const tmpDest = `${backupConfig.dbPath}.restore-${Date.now()}`
+      await fs.promises.copyFile(tmpRaw, tmpDest)
+      await fs.promises.rename(tmpDest, backupConfig.dbPath)
       logger.info('Database restored successfully', { dbPath: backupConfig.dbPath })
 
       const durationMs = Date.now() - start
@@ -211,9 +214,10 @@ export class BackupService {
     const db = new Database(filePath, { readonly: true })
     try {
       // SQLite magic header check: first 16 bytes should be "SQLite format 3\000"
-      const integrity = db.prepare('PRAGMA integrity_check').get() as { integrity_check: string }
-      if (integrity.integrity_check !== 'ok') {
-        throw new Error(`SQLite integrity check failed: ${integrity.integrity_check}`)
+      const rows = db.prepare('PRAGMA integrity_check').all() as Array<{ integrity_check: string }>
+      const errors = rows.filter((r) => r.integrity_check !== 'ok')
+      if (errors.length > 0) {
+        throw new Error(`SQLite integrity check failed: ${errors.map((r) => r.integrity_check).join('; ')}`)
       }
     } finally {
       db.close()

--- a/backend/src/services/backupService.ts
+++ b/backend/src/services/backupService.ts
@@ -12,7 +12,7 @@ import {
   uploadToS3,
   downloadFromS3,
 } from '../utils/backupUtils'
-import { logger } from '../utils/logger'
+import { winstonLogger as logger } from '../utils/logger'
 
 export interface BackupResult {
   filename: string

--- a/backend/src/services/backupService.ts
+++ b/backend/src/services/backupService.ts
@@ -1,0 +1,224 @@
+import path from 'node:path'
+import fs from 'node:fs'
+import os from 'node:os'
+import Database from 'better-sqlite3'
+import { backupConfig } from '../config/backup'
+import {
+  buildBackupFilename,
+  compressFile,
+  decompressFile,
+  encryptFile,
+  decryptFile,
+  uploadToS3,
+  downloadFromS3,
+} from '../utils/backupUtils'
+import { logger } from '../utils/logger'
+
+export interface BackupResult {
+  filename: string
+  localPath: string
+  sizeBytes: number
+  encrypted: boolean
+  uploadedToS3: boolean
+  durationMs: number
+}
+
+export interface RestoreResult {
+  restoredFrom: string
+  durationMs: number
+}
+
+export class BackupService {
+  private get encrypted(): boolean {
+    return backupConfig.encryptionKey.length === 64
+  }
+
+  /**
+   * Create a live-safe backup of the SQLite database, compress it, optionally
+   * encrypt it, and store it locally (and in S3 if configured).
+   */
+  async createBackup(): Promise<BackupResult> {
+    const start = Date.now()
+    await fs.promises.mkdir(backupConfig.dir, { recursive: true })
+
+    const tmpRaw = path.join(os.tmpdir(), `chenaikit-backup-raw-${Date.now()}.db`)
+    const tmpGz = path.join(os.tmpdir(), `chenaikit-backup-${Date.now()}.gz`)
+    const filename = buildBackupFilename(this.encrypted)
+    const localPath = path.join(backupConfig.dir, filename)
+
+    try {
+      // Step 1: hot backup via SQLite Online Backup API (live-safe, no read lock)
+      logger.info('Starting SQLite backup', { dbPath: backupConfig.dbPath })
+      await this.sqliteBackup(backupConfig.dbPath, tmpRaw)
+
+      // Step 2: compress
+      await compressFile(tmpRaw, tmpGz)
+
+      // Step 3: optionally encrypt
+      if (this.encrypted) {
+        await encryptFile(tmpGz, localPath, backupConfig.encryptionKey)
+      } else {
+        await fs.promises.copyFile(tmpGz, localPath)
+      }
+
+      const { size: sizeBytes } = await fs.promises.stat(localPath)
+
+      // Step 4: upload to S3 if configured
+      let uploadedToS3 = false
+      if (backupConfig.s3Bucket && backupConfig.awsAccessKeyId) {
+        const s3Key = `${backupConfig.s3Prefix}${filename}`
+        logger.info('Uploading backup to S3', { bucket: backupConfig.s3Bucket, key: s3Key })
+        await uploadToS3({
+          filePath: localPath,
+          bucket: backupConfig.s3Bucket,
+          key: s3Key,
+          region: backupConfig.s3Region,
+          accessKeyId: backupConfig.awsAccessKeyId,
+          secretAccessKey: backupConfig.awsSecretAccessKey,
+        })
+        uploadedToS3 = true
+        logger.info('Backup uploaded to S3 successfully', { key: s3Key })
+      }
+
+      // Step 5: prune old local backups
+      await this.pruneLocalBackups()
+
+      const durationMs = Date.now() - start
+      const result: BackupResult = { filename, localPath, sizeBytes, encrypted: this.encrypted, uploadedToS3, durationMs }
+      logger.info('Backup completed', result)
+      return result
+    } finally {
+      await fs.promises.rm(tmpRaw, { force: true })
+      await fs.promises.rm(tmpGz, { force: true })
+    }
+  }
+
+  /**
+   * Restore the database from a local backup file path or an S3 key.
+   *
+   * @param source  Absolute path to a local backup file, or an S3 key
+   *                (detected when the value does not start with '/' or '.').
+   */
+  async restore(source: string): Promise<RestoreResult> {
+    const start = Date.now()
+    const isS3Key = !path.isAbsolute(source) && !source.startsWith('.')
+
+    const tmpEncOrGz = path.join(os.tmpdir(), `chenaikit-restore-dl-${Date.now()}`)
+    const tmpGz = path.join(os.tmpdir(), `chenaikit-restore-gz-${Date.now()}.gz`)
+    const tmpRaw = path.join(os.tmpdir(), `chenaikit-restore-raw-${Date.now()}.db`)
+
+    try {
+      // Step 1: fetch the file (from S3 or local disk)
+      if (isS3Key) {
+        if (!backupConfig.s3Bucket || !backupConfig.awsAccessKeyId) {
+          throw new Error('S3_BUCKET and AWS credentials are required to restore from S3')
+        }
+        logger.info('Downloading backup from S3', { key: source })
+        await downloadFromS3({
+          destPath: tmpEncOrGz,
+          bucket: backupConfig.s3Bucket,
+          key: source,
+          region: backupConfig.s3Region,
+          accessKeyId: backupConfig.awsAccessKeyId,
+          secretAccessKey: backupConfig.awsSecretAccessKey,
+        })
+      } else {
+        await fs.promises.copyFile(source, tmpEncOrGz)
+      }
+
+      // Step 2: decrypt if the file looks encrypted (filename ends with .enc.gz)
+      const sourceName = isS3Key ? source : path.basename(source)
+      const needsDecrypt = sourceName.includes('.enc.')
+      if (needsDecrypt) {
+        if (!this.encrypted) {
+          throw new Error('Backup file is encrypted but BACKUP_ENCRYPTION_KEY is not set')
+        }
+        logger.info('Decrypting backup file')
+        await decryptFile(tmpEncOrGz, tmpGz, backupConfig.encryptionKey)
+      } else {
+        await fs.promises.copyFile(tmpEncOrGz, tmpGz)
+      }
+
+      // Step 3: decompress
+      logger.info('Decompressing backup file')
+      await decompressFile(tmpGz, tmpRaw)
+
+      // Step 4: verify the restored file is a valid SQLite database
+      this.verifySqlite(tmpRaw)
+
+      // Step 5: atomically replace the live database
+      await fs.promises.copyFile(tmpRaw, backupConfig.dbPath)
+      logger.info('Database restored successfully', { dbPath: backupConfig.dbPath })
+
+      const durationMs = Date.now() - start
+      const result: RestoreResult = { restoredFrom: source, durationMs }
+      logger.info('Restore completed', result)
+      return result
+    } finally {
+      await fs.promises.rm(tmpEncOrGz, { force: true })
+      await fs.promises.rm(tmpGz, { force: true })
+      await fs.promises.rm(tmpRaw, { force: true })
+    }
+  }
+
+  /**
+   * List local backup files sorted newest-first.
+   */
+  async listLocalBackups(): Promise<Array<{ filename: string; sizeBytes: number; createdAt: Date }>> {
+    try {
+      await fs.promises.mkdir(backupConfig.dir, { recursive: true })
+      const files = await fs.promises.readdir(backupConfig.dir)
+      const backups = await Promise.all(
+        files
+          .filter((f) => f.startsWith('backup-') && (f.endsWith('.gz') || f.endsWith('.enc.gz')))
+          .map(async (filename) => {
+            const stat = await fs.promises.stat(path.join(backupConfig.dir, filename))
+            return { filename, sizeBytes: stat.size, createdAt: stat.birthtime }
+          }),
+      )
+      return backups.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+    } catch {
+      return []
+    }
+  }
+
+  /** Remove oldest local backups beyond the retention count. */
+  private async pruneLocalBackups(): Promise<void> {
+    const backups = await this.listLocalBackups()
+    const toDelete = backups.slice(backupConfig.retentionCount)
+    for (const { filename } of toDelete) {
+      const filePath = path.join(backupConfig.dir, filename)
+      await fs.promises.rm(filePath, { force: true })
+      logger.info('Pruned old backup', { filename })
+    }
+  }
+
+  /**
+   * Use better-sqlite3's Online Backup API for a live-safe, consistent copy.
+   * This copies the database page-by-page without taking an exclusive lock.
+   */
+  private async sqliteBackup(srcPath: string, destPath: string): Promise<void> {
+    const db = new Database(srcPath, { readonly: true })
+    try {
+      await db.backup(destPath)
+    } finally {
+      db.close()
+    }
+  }
+
+  /** Throw if the file at `filePath` is not a valid SQLite database. */
+  private verifySqlite(filePath: string): void {
+    const db = new Database(filePath, { readonly: true })
+    try {
+      // SQLite magic header check: first 16 bytes should be "SQLite format 3\000"
+      const integrity = db.prepare('PRAGMA integrity_check').get() as { integrity_check: string }
+      if (integrity.integrity_check !== 'ok') {
+        throw new Error(`SQLite integrity check failed: ${integrity.integrity_check}`)
+      }
+    } finally {
+      db.close()
+    }
+  }
+}
+
+export const backupService = new BackupService()

--- a/backend/src/utils/backupUtils.ts
+++ b/backend/src/utils/backupUtils.ts
@@ -1,0 +1,235 @@
+import crypto from 'node:crypto'
+import zlib from 'node:zlib'
+import fs from 'node:fs'
+import { pipeline } from 'node:stream/promises'
+
+const IV_LENGTH = 12   // AES-GCM recommended IV size
+const TAG_LENGTH = 16  // GCM auth tag
+
+/**
+ * Compress a file with gzip and write the result to destPath.
+ */
+export async function compressFile(srcPath: string, destPath: string): Promise<void> {
+  await pipeline(
+    fs.createReadStream(srcPath),
+    zlib.createGzip(),
+    fs.createWriteStream(destPath),
+  )
+}
+
+/**
+ * Decompress a gzip file and write the result to destPath.
+ */
+export async function decompressFile(srcPath: string, destPath: string): Promise<void> {
+  await pipeline(
+    fs.createReadStream(srcPath),
+    zlib.createGunzip(),
+    fs.createWriteStream(destPath),
+  )
+}
+
+/**
+ * Encrypt a file using AES-256-GCM.
+ * Output format: [iv (12 bytes)][auth tag (16 bytes)][ciphertext]
+ *
+ * @param srcPath     Plaintext input file path
+ * @param destPath    Encrypted output file path
+ * @param hexKey      32-byte encryption key as a 64-char hex string
+ */
+export async function encryptFile(srcPath: string, destPath: string, hexKey: string): Promise<void> {
+  const key = Buffer.from(hexKey, 'hex')
+  if (key.length !== 32) throw new Error('Encryption key must be 32 bytes (64 hex chars)')
+
+  const plaintext = await fs.promises.readFile(srcPath)
+  const iv = crypto.randomBytes(IV_LENGTH)
+  const cipher = crypto.createCipheriv('aes-256-gcm', key, iv)
+
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()])
+  const tag = cipher.getAuthTag()
+
+  // Layout: [iv][tag][ciphertext]
+  await fs.promises.writeFile(destPath, Buffer.concat([iv, tag, ciphertext]))
+}
+
+/**
+ * Decrypt a file that was encrypted with encryptFile.
+ */
+export async function decryptFile(srcPath: string, destPath: string, hexKey: string): Promise<void> {
+  const key = Buffer.from(hexKey, 'hex')
+  if (key.length !== 32) throw new Error('Encryption key must be 32 bytes (64 hex chars)')
+
+  const data = await fs.promises.readFile(srcPath)
+  const iv = data.subarray(0, IV_LENGTH)
+  const tag = data.subarray(IV_LENGTH, IV_LENGTH + TAG_LENGTH)
+  const ciphertext = data.subarray(IV_LENGTH + TAG_LENGTH)
+
+  const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv)
+  decipher.setAuthTag(tag)
+
+  const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()])
+  await fs.promises.writeFile(destPath, plaintext)
+}
+
+/**
+ * Build a timestamped backup filename.
+ * Pattern: backup-YYYY-MM-DDTHH-mm-ssZ[.enc].gz
+ */
+export function buildBackupFilename(encrypted: boolean): string {
+  const ts = new Date().toISOString().replace(/[:.]/g, '-')
+  return encrypted ? `backup-${ts}.enc.gz` : `backup-${ts}.gz`
+}
+
+/**
+ * Upload a file to S3 using a plain HTTPS PUT request signed with AWS Sig V4.
+ * Does not require @aws-sdk — uses only Node.js built-ins.
+ */
+export async function uploadToS3(params: {
+  filePath: string
+  bucket: string
+  key: string
+  region: string
+  accessKeyId: string
+  secretAccessKey: string
+}): Promise<void> {
+  const { filePath, bucket, key, region, accessKeyId, secretAccessKey } = params
+  const body = await fs.promises.readFile(filePath)
+  const host = `${bucket}.s3.${region}.amazonaws.com`
+  const url = `https://${host}/${key}`
+
+  const now = new Date()
+  const amzDate = now.toISOString().replace(/[:-]|\.\d{3}/g, '').slice(0, 15) + 'Z'
+  const dateStamp = amzDate.slice(0, 8)
+
+  const contentHash = crypto.createHash('sha256').update(body).digest('hex')
+  const contentType = 'application/octet-stream'
+
+  const signedHeaders = 'content-type;host;x-amz-content-sha256;x-amz-date'
+  const canonicalHeaders =
+    `content-type:${contentType}\n` +
+    `host:${host}\n` +
+    `x-amz-content-sha256:${contentHash}\n` +
+    `x-amz-date:${amzDate}\n`
+
+  const canonicalRequest = [
+    'PUT',
+    `/${key}`,
+    '',
+    canonicalHeaders,
+    signedHeaders,
+    contentHash,
+  ].join('\n')
+
+  const credentialScope = `${dateStamp}/${region}/s3/aws4_request`
+  const stringToSign = [
+    'AWS4-HMAC-SHA256',
+    amzDate,
+    credentialScope,
+    crypto.createHash('sha256').update(canonicalRequest).digest('hex'),
+  ].join('\n')
+
+  const hmac = (key: Buffer | string, data: string) =>
+    crypto.createHmac('sha256', key).update(data).digest()
+
+  const signingKey = hmac(
+    hmac(
+      hmac(
+        hmac(`AWS4${secretAccessKey}`, dateStamp),
+        region,
+      ),
+      's3',
+    ),
+    'aws4_request',
+  )
+
+  const signature = hmac(signingKey, stringToSign).toString('hex')
+
+  const authorization =
+    `AWS4-HMAC-SHA256 Credential=${accessKeyId}/${credentialScope}, ` +
+    `SignedHeaders=${signedHeaders}, Signature=${signature}`
+
+  const response = await fetch(url, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': contentType,
+      'Host': host,
+      'x-amz-content-sha256': contentHash,
+      'x-amz-date': amzDate,
+      'Authorization': authorization,
+    },
+    body,
+  })
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '')
+    throw new Error(`S3 upload failed (${response.status}): ${text}`)
+  }
+}
+
+/**
+ * Download an object from S3 to a local file using AWS Sig V4.
+ */
+export async function downloadFromS3(params: {
+  destPath: string
+  bucket: string
+  key: string
+  region: string
+  accessKeyId: string
+  secretAccessKey: string
+}): Promise<void> {
+  const { destPath, bucket, key, region, accessKeyId, secretAccessKey } = params
+  const host = `${bucket}.s3.${region}.amazonaws.com`
+  const url = `https://${host}/${key}`
+
+  const now = new Date()
+  const amzDate = now.toISOString().replace(/[:-]|\.\d{3}/g, '').slice(0, 15) + 'Z'
+  const dateStamp = amzDate.slice(0, 8)
+
+  const contentHash = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'  // sha256('')
+
+  const signedHeaders = 'host;x-amz-content-sha256;x-amz-date'
+  const canonicalHeaders =
+    `host:${host}\n` +
+    `x-amz-content-sha256:${contentHash}\n` +
+    `x-amz-date:${amzDate}\n`
+
+  const canonicalRequest = ['GET', `/${key}`, '', canonicalHeaders, signedHeaders, contentHash].join('\n')
+
+  const credentialScope = `${dateStamp}/${region}/s3/aws4_request`
+  const stringToSign = [
+    'AWS4-HMAC-SHA256',
+    amzDate,
+    credentialScope,
+    crypto.createHash('sha256').update(canonicalRequest).digest('hex'),
+  ].join('\n')
+
+  const hmac = (key: Buffer | string, data: string) =>
+    crypto.createHmac('sha256', key).update(data).digest()
+
+  const signingKey = hmac(
+    hmac(hmac(hmac(`AWS4${secretAccessKey}`, dateStamp), region), 's3'),
+    'aws4_request',
+  )
+
+  const signature = hmac(signingKey, stringToSign).toString('hex')
+  const authorization =
+    `AWS4-HMAC-SHA256 Credential=${accessKeyId}/${credentialScope}, ` +
+    `SignedHeaders=${signedHeaders}, Signature=${signature}`
+
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: {
+      Host: host,
+      'x-amz-content-sha256': contentHash,
+      'x-amz-date': amzDate,
+      Authorization: authorization,
+    },
+  })
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '')
+    throw new Error(`S3 download failed (${response.status}): ${text}`)
+  }
+
+  const arrayBuffer = await response.arrayBuffer()
+  await fs.promises.writeFile(destPath, Buffer.from(arrayBuffer))
+}

--- a/backend/src/utils/backupUtils.ts
+++ b/backend/src/utils/backupUtils.ts
@@ -94,10 +94,12 @@ export async function uploadToS3(params: {
   const { filePath, bucket, key, region, accessKeyId, secretAccessKey } = params
   const body = await fs.promises.readFile(filePath)
   const host = `${bucket}.s3.${region}.amazonaws.com`
-  const url = `https://${host}/${key}`
+  const encodedKey = key.split('/').map(encodeURIComponent).join('/')
+  const url = `https://${host}/${encodedKey}`
 
   const now = new Date()
-  const amzDate = now.toISOString().replace(/[:-]|\.\d{3}/g, '').slice(0, 15) + 'Z'
+  const pad = (n: number) => String(n).padStart(2, '0')
+  const amzDate = `${now.getUTCFullYear()}${pad(now.getUTCMonth() + 1)}${pad(now.getUTCDate())}T${pad(now.getUTCHours())}${pad(now.getUTCMinutes())}${pad(now.getUTCSeconds())}Z`
   const dateStamp = amzDate.slice(0, 8)
 
   const contentHash = crypto.createHash('sha256').update(body).digest('hex')
@@ -112,7 +114,7 @@ export async function uploadToS3(params: {
 
   const canonicalRequest = [
     'PUT',
-    `/${key}`,
+    `/${encodedKey}`,
     '',
     canonicalHeaders,
     signedHeaders,
@@ -178,10 +180,12 @@ export async function downloadFromS3(params: {
 }): Promise<void> {
   const { destPath, bucket, key, region, accessKeyId, secretAccessKey } = params
   const host = `${bucket}.s3.${region}.amazonaws.com`
-  const url = `https://${host}/${key}`
+  const encodedKey = key.split('/').map(encodeURIComponent).join('/')
+  const url = `https://${host}/${encodedKey}`
 
   const now = new Date()
-  const amzDate = now.toISOString().replace(/[:-]|\.\d{3}/g, '').slice(0, 15) + 'Z'
+  const pad = (n: number) => String(n).padStart(2, '0')
+  const amzDate = `${now.getUTCFullYear()}${pad(now.getUTCMonth() + 1)}${pad(now.getUTCDate())}T${pad(now.getUTCHours())}${pad(now.getUTCMinutes())}${pad(now.getUTCSeconds())}Z`
   const dateStamp = amzDate.slice(0, 8)
 
   const contentHash = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'  // sha256('')
@@ -192,7 +196,7 @@ export async function downloadFromS3(params: {
     `x-amz-content-sha256:${contentHash}\n` +
     `x-amz-date:${amzDate}\n`
 
-  const canonicalRequest = ['GET', `/${key}`, '', canonicalHeaders, signedHeaders, contentHash].join('\n')
+  const canonicalRequest = ['GET', `/${encodedKey}`, '', canonicalHeaders, signedHeaders, contentHash].join('\n')
 
   const credentialScope = `${dateStamp}/${region}/s3/aws4_request`
   const stringToSign = [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,6 +172,9 @@ importers:
       '@types/bcrypt':
         specifier: ^6.0.0
         version: 6.0.0
+      '@types/better-sqlite3':
+        specifier: ^7.6.0
+        version: 7.6.13
       '@types/bull':
         specifier: ^4.10.0
         version: 4.10.4
@@ -3199,6 +3202,9 @@ packages:
 
   '@types/bcrypt@6.0.0':
     resolution: {integrity: sha512-/oJGukuH3D2+D+3H4JWLaAsJ/ji86dhRidzZ/Od7H/i8g+aCmvkeCc6Ni/f9uxGLSQVCRZkX2/lqEFG2BvWtlQ==}
+
+  '@types/better-sqlite3@7.6.13':
+    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
 
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
@@ -13520,6 +13526,10 @@ snapshots:
       '@babel/types': 7.29.7
 
   '@types/bcrypt@6.0.0':
+    dependencies:
+      '@types/node': 20.19.43
+
+  '@types/better-sqlite3@7.6.13':
     dependencies:
       '@types/node': 20.19.43
 


### PR DESCRIPTION
## Summary

- Implements SQLite hot backup using `better-sqlite3`'s Online Backup API (live-safe, no read lock)
- AES-256-GCM encryption with configurable key; gzip compression; local retention pruning
- S3 upload/download via native AWS Sig V4 signing — no `@aws-sdk` dependency required
- Bull cron scheduling for automated nightly backups; CLI scripts for manual backup and restore

## Test plan

- [x] `createBackup` creates an encrypted `.enc.gz` file in the backup directory
- [x] Backup produces a restorable snapshot (verified by dropping and re-inserting data)
- [x] Retention pruning keeps only the `N` newest files
- [x] `restore` successfully reconstructs the database from an encrypted backup
- [x] `restore` throws with a helpful message when encryption key is missing
- [x] `restore` throws on nonexistent source file
- [x] `listLocalBackups` returns entries sorted newest-first
- [x] `listLocalBackups` returns empty array when backup directory does not exist

Closes nexoraorg/chenaikit#184

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a SQLite database backup/restore capability with gzip compression, optional AES-256-GCM encryption, and integrity checking.
  * Enabled scheduled cron backups plus on-demand triggering through a background job queue.
  * Added environment-driven backup configuration supporting local retention and optional S3 off-site uploads/downloads.
  * Introduced CLI tools to run backups and restore from local paths or S3 keys, including interactive confirmation.
  * Added local backup listing (newest-first) and automatic pruning.
* **Tests**
  * Added a comprehensive Jest test suite covering backup creation/restore, encryption and error cases, and listing/pruning behavior using a temporary workspace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->