### PR TITLE
Feat/dark mode theme

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,8 @@ import DataVisualizationExample from './components/DataVisualizationExample';
 import { AnalyticsDashboard } from './components';
 import { AuthProvider, useAuth } from './components/auth/AuthContext';
 import ProtectedRoute from './components/auth/ProtectedRoute';
+import { ThemeProvider } from './contexts/ThemeContext';
+import ThemeToggle from './components/ThemeToggle';
 import Login from './pages/Login';
 import Signup from './pages/Signup';
 import Profile from './pages/Profile';
@@ -14,37 +16,43 @@ import Settings from './pages/Settings';
 import './components/FormValidation.css';
 
 // Stub page components for policy/auth routes
-const ForgotPasswordPage: React.FC = () => (
-  <Box sx={{ minHeight: '100vh', display: 'flex', justifyContent: 'center', alignItems: 'center', background: '#f8fafc' }}>
-    <Box sx={{ maxWidth: 480, width: '100%', p: 4, borderRadius: 3, boxShadow: '0 4px 32px rgba(0,0,0,0.08)', background: '#fff' }}>
-      <Typography variant="h5" sx={{ fontWeight: 700, mb: 1, color: '#0f172a' }}>Reset your password</Typography>
-      <Typography variant="body2" sx={{ color: '#64748b', mb: 3 }}>Enter your email address and we'll send you a password reset link.</Typography>
-      <Typography variant="caption" sx={{ color: '#94a3b8' }}>Password reset functionality coming soon.</Typography>
+const ForgotPasswordPage: React.FC = () => {
+  return (
+    <Box sx={{ minHeight: '100vh', display: 'flex', justifyContent: 'center', alignItems: 'center', bgcolor: 'background.default' }}>
+      <Box sx={{ maxWidth: 480, width: '100%', p: 4, borderRadius: 3, boxShadow: '0 4px 32px rgba(0,0,0,0.08)', bgcolor: 'background.paper' }}>
+        <Typography variant="h5" sx={{ fontWeight: 700, mb: 1, color: 'text.primary' }}>Reset your password</Typography>
+        <Typography variant="body2" sx={{ color: 'text.secondary', mb: 3 }}>Enter your email address and we'll send you a password reset link.</Typography>
+        <Typography variant="caption" sx={{ color: 'text.disabled' }}>Password reset functionality coming soon.</Typography>
+      </Box>
     </Box>
-  </Box>
-);
+  );
+};
 
-const TermsPage: React.FC = () => (
-  <Box sx={{ minHeight: '100vh', p: { xs: 3, md: 6 }, background: '#f8fafc' }}>
-    <Box sx={{ maxWidth: 800, mx: 'auto' }}>
-      <Typography variant="h4" sx={{ fontWeight: 800, mb: 3, color: '#0f172a' }}>Terms of Service</Typography>
-      <Typography variant="body1" sx={{ color: '#475569', lineHeight: 1.8 }}>
-        These Terms of Service govern your use of ChenaiKit. By accessing or using our platform, you agree to be bound by these terms. Full terms documentation will be published here prior to production launch.
-      </Typography>
+const TermsPage: React.FC = () => {
+  return (
+    <Box sx={{ minHeight: '100vh', p: { xs: 3, md: 6 }, bgcolor: 'background.default' }}>
+      <Box sx={{ maxWidth: 800, mx: 'auto' }}>
+        <Typography variant="h4" sx={{ fontWeight: 800, mb: 3, color: 'text.primary' }}>Terms of Service</Typography>
+        <Typography variant="body1" sx={{ color: 'text.secondary', lineHeight: 1.8 }}>
+          These Terms of Service govern your use of ChenaiKit. By accessing or using our platform, you agree to be bound by these terms. Full terms documentation will be published here prior to production launch.
+        </Typography>
+      </Box>
     </Box>
-  </Box>
-);
+  );
+};
 
-const PrivacyPage: React.FC = () => (
-  <Box sx={{ minHeight: '100vh', p: { xs: 3, md: 6 }, background: '#f8fafc' }}>
-    <Box sx={{ maxWidth: 800, mx: 'auto' }}>
-      <Typography variant="h4" sx={{ fontWeight: 800, mb: 3, color: '#0f172a' }}>Privacy Policy</Typography>
-      <Typography variant="body1" sx={{ color: '#475569', lineHeight: 1.8 }}>
-        Your privacy is important to us. ChenaiKit collects only the data necessary to provide our services and never sells personal information to third parties. Full privacy policy documentation will be published here prior to production launch.
-      </Typography>
+const PrivacyPage: React.FC = () => {
+  return (
+    <Box sx={{ minHeight: '100vh', p: { xs: 3, md: 6 }, bgcolor: 'background.default' }}>
+      <Box sx={{ maxWidth: 800, mx: 'auto' }}>
+        <Typography variant="h4" sx={{ fontWeight: 800, mb: 3, color: 'text.primary' }}>Privacy Policy</Typography>
+        <Typography variant="body1" sx={{ color: 'text.secondary', lineHeight: 1.8 }}>
+          Your privacy is important to us. ChenaiKit collects only the data necessary to provide our services and never sells personal information to third parties. Full privacy policy documentation will be published here prior to production launch.
+        </Typography>
+      </Box>
     </Box>
-  </Box>
-);
+  );
+};
 
 const DashboardShell: React.FC = () => {
   const [activeDemo, setActiveDemo] = useState<'analytics' | 'forms' | 'visualization'>('analytics');
@@ -66,10 +74,11 @@ const DashboardShell: React.FC = () => {
             right: 20, 
             display: 'flex', 
             alignItems: 'center', 
-            gap: 1.5,
+            gap: 1,
             justifyContent: 'center',
             mb: { xs: 2, sm: 0 }
           }}>
+            <ThemeToggle />
             <AccountCircle sx={{ color: '#38bdf8' }} />
             <Typography variant="body2" sx={{ fontWeight: 500, color: '#e2e8f0' }}>
               {user.email}
@@ -194,24 +203,29 @@ const DashboardShell: React.FC = () => {
         {activeDemo === 'visualization' && <DataVisualizationExample />}
       </main>
       
-      <footer style={{ 
-        background: '#F9FAFB', 
-        padding: '20px', 
-        textAlign: 'center', 
-        borderTop: '1px solid #E5E7EB' 
-      }}>
-        <p style={{ color: '#6B7280', fontSize: '14px' }}>
-          Built with ChenaiKit - Advanced AI and Blockchain Solutions
-        </p>
-      </footer>
+      <Box
+        component="footer"
+        sx={{
+          bgcolor: 'grey.100',
+          py: 2.5,
+          textAlign: 'center',
+          borderTop: '1px solid',
+          borderColor: 'divider',
+          color: 'text.secondary',
+          typography: 'body2',
+        }}
+      >
+        Built with ChenaiKit - Advanced AI and Blockchain Solutions
+      </Box>
     </div>
   );
 };
 
 const App: React.FC = () => {
   return (
-    <AuthProvider>
-      <BrowserRouter>
+    <ThemeProvider>
+      <AuthProvider>
+        <BrowserRouter>
         <Routes>
           <Route path="/login" element={<Login />} />
           <Route path="/signup" element={<Signup />} />
@@ -334,8 +348,9 @@ const App: React.FC = () => {
           />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
-      </BrowserRouter>
-    </AuthProvider>
+        </BrowserRouter>
+      </AuthProvider>
+    </ThemeProvider>
   );
 };
 

--- a/frontend/src/components/AnalyticsDashboard.tsx
+++ b/frontend/src/components/AnalyticsDashboard.tsx
@@ -98,13 +98,13 @@ export const AnalyticsDashboard: React.FC = () => {
   );
 
   return (
-    <Box sx={{ flexGrow: 1, p: 4, backgroundColor: '#F9FAFB', minHeight: '100vh' }}>
+    <Box sx={{ flexGrow: 1, p: 4, bgcolor: 'background.default', minHeight: '100vh' }}>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 4 }}>
         <Box>
-          <Typography variant="h4" sx={{ fontWeight: 700, color: '#111827' }}>
+          <Typography variant="h4" sx={{ fontWeight: 700, color: 'text.primary' }}>
             Business Intelligence Dashboard
           </Typography>
-          <Typography variant="subtitle1" sx={{ color: '#6B7280' }}>
+          <Typography variant="subtitle1" sx={{ color: 'text.secondary' }}>
             Real-time insights across systems, AI, and blockchain
           </Typography>
         </Box>

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { IconButton, Tooltip } from '@mui/material';
+import { DarkMode, LightMode } from '@mui/icons-material';
+import { useThemeMode } from '../contexts/ThemeContext';
+
+export const ThemeToggle: React.FC = () => {
+  const { mode, toggleTheme } = useThemeMode();
+
+  return (
+    <Tooltip title={`Switch to ${mode === 'light' ? 'dark' : 'light'} mode (Ctrl+D)`}>
+      <IconButton
+        onClick={toggleTheme}
+        sx={{
+          color: 'rgba(255,255,255,0.8)',
+          '&:hover': {
+            color: 'white',
+            backgroundColor: 'rgba(255,255,255,0.1)',
+          },
+        }}
+      >
+        {mode === 'light' ? <DarkMode /> : <LightMode />}
+      </IconButton>
+    </Tooltip>
+  );
+};
+
+export default ThemeToggle;

--- a/frontend/src/components/auth/LoginForm.tsx
+++ b/frontend/src/components/auth/LoginForm.tsx
@@ -73,10 +73,10 @@ export const LoginForm: React.FC = () => {
   return (
     <Box sx={{ width: '100%' }}>
       <Box sx={{ mb: 4, textAlign: 'center' }}>
-        <Typography variant="h4" sx={{ fontWeight: 800, mb: 1, color: '#0f172a' }}>
+        <Typography variant="h4" sx={{ fontWeight: 800, mb: 1, color: 'text.primary' }}>
           Welcome back
         </Typography>
-        <Typography variant="body2" sx={{ color: '#64748b' }}>
+        <Typography variant="body2" sx={{ color: 'text.secondary' }}>
           Enter your details to access your dashboard
         </Typography>
       </Box>
@@ -158,9 +158,9 @@ export const LoginForm: React.FC = () => {
                 />
               }
               label={
-                <Typography variant="body2" sx={{ color: '#475569', userSelect: 'none' }}>
-                  Remember me
-                </Typography>
+            <Typography variant="body2" sx={{ color: 'text.secondary', userSelect: 'none' }}>
+              Remember me
+            </Typography>
               }
             />
             <MuiLink
@@ -168,7 +168,7 @@ export const LoginForm: React.FC = () => {
               to="/forgot-password"
               variant="body2"
               sx={{ 
-                color: '#0284c7', 
+                color: 'primary.main', 
                 textDecoration: 'none', 
                 fontWeight: 600,
                 '&:hover': { textDecoration: 'underline' }
@@ -183,18 +183,14 @@ export const LoginForm: React.FC = () => {
             variant="contained"
             disabled={isSubmitting || !isValid}
             fullWidth
-            sx={{
-              py: 1.5,
-              borderRadius: '10px',
-              textTransform: 'none',
-              fontSize: '16px',
-              fontWeight: 600,
-              boxShadow: '0 4px 12px rgba(2, 132, 199, 0.2)',
-              background: 'linear-gradient(135deg, #0284c7 0%, #0369a1 100%)',
-              '&:hover': {
-                background: 'linear-gradient(135deg, #0369a1 0%, #075985 100%)',
-              }
-            }}
+              sx={{
+                py: 1.5,
+                borderRadius: '10px',
+                textTransform: 'none',
+                fontSize: '16px',
+                fontWeight: 600,
+                boxShadow: (theme) => theme.shadows[4],
+              }}
           >
             {isSubmitting ? (
               <CircularProgress size={24} sx={{ color: 'white' }} />
@@ -203,8 +199,8 @@ export const LoginForm: React.FC = () => {
             )}
           </Button>
 
-          <Divider sx={{ my: 1.5, color: '#94a3b8' }}>
-            <Typography variant="caption" sx={{ px: 1, color: '#64748b', fontWeight: 500 }}>
+          <Divider sx={{ my: 1.5, color: 'text.disabled' }}>
+            <Typography variant="caption" sx={{ px: 1, color: 'text.secondary', fontWeight: 500 }}>
               OR CONTINUE WITH
             </Typography>
           </Divider>
@@ -218,13 +214,13 @@ export const LoginForm: React.FC = () => {
               sx={{
                 py: 1.2,
                 borderRadius: '10px',
-                borderColor: '#e2e8f0',
-                color: '#334155',
+                borderColor: 'divider',
+                color: 'text.primary',
                 textTransform: 'none',
                 fontWeight: 500,
                 '&:hover': {
-                  borderColor: '#cbd5e1',
-                  backgroundColor: '#f8fafc'
+                  borderColor: 'action.hover',
+                  backgroundColor: 'action.hover'
                 }
               }}
             >
@@ -238,13 +234,13 @@ export const LoginForm: React.FC = () => {
               sx={{
                 py: 1.2,
                 borderRadius: '10px',
-                borderColor: '#e2e8f0',
-                color: '#334155',
+                borderColor: 'divider',
+                color: 'text.primary',
                 textTransform: 'none',
                 fontWeight: 500,
                 '&:hover': {
-                  borderColor: '#cbd5e1',
-                  backgroundColor: '#f8fafc'
+                  borderColor: 'action.hover',
+                  backgroundColor: 'action.hover'
                 }
               }}
             >
@@ -253,13 +249,13 @@ export const LoginForm: React.FC = () => {
           </Box>
 
           <Box sx={{ textAlign: 'center', mt: 3 }}>
-            <Typography variant="body2" sx={{ color: '#64748b' }}>
+            <Typography variant="body2" sx={{ color: 'text.secondary' }}>
               Don't have an account?{' '}
               <MuiLink
                 component={Link}
                 to="/signup"
                 sx={{
-                  color: '#0284c7',
+                  color: 'primary.main',
                   textDecoration: 'none',
                   fontWeight: 600,
                   '&:hover': { textDecoration: 'underline' }

--- a/frontend/src/components/auth/SignupForm.tsx
+++ b/frontend/src/components/auth/SignupForm.tsx
@@ -109,26 +109,25 @@ export const SignupForm: React.FC = () => {
         <Box sx={{ display: 'flex', justifyContent: 'center', mb: 3 }}>
           <CheckCircleOutline sx={{ fontSize: 72, color: '#34d399' }} />
         </Box>
-        <Typography variant="h4" sx={{ fontWeight: 800, mb: 2, color: '#0f172a' }}>
+        <Typography variant="h4" sx={{ fontWeight: 800, mb: 2, color: 'text.primary' }}>
           Account Created!
         </Typography>
-        <Typography variant="body1" sx={{ color: '#475569', mb: 4, px: 2 }}>
+        <Typography variant="body1" sx={{ color: 'text.secondary', mb: 4, px: 2 }}>
           Your account was created for <strong>{registeredEmail}</strong>. You can now sign in to continue.
         </Typography>
-        <Button
-          component={Link}
-          to="/login"
-          variant="contained"
-          sx={{
-            py: 1.5,
-            px: 4,
-            borderRadius: '10px',
-            textTransform: 'none',
-            fontSize: '16px',
-            fontWeight: 600,
-            background: 'linear-gradient(135deg, #0284c7 0%, #0369a1 100%)',
-          }}
-        >
+          <Button
+            component={Link}
+            to="/login"
+            variant="contained"
+            sx={{
+              py: 1.5,
+              px: 4,
+              borderRadius: '10px',
+              textTransform: 'none',
+              fontSize: '16px',
+              fontWeight: 600,
+            }}
+          >
           Go to Sign In
         </Button>
       </Box>
@@ -138,10 +137,10 @@ export const SignupForm: React.FC = () => {
   return (
     <Box sx={{ width: '100%' }}>
       <Box sx={{ mb: 3, textAlign: 'center' }}>
-        <Typography variant="h4" sx={{ fontWeight: 800, mb: 1, color: '#0f172a' }}>
+        <Typography variant="h4" sx={{ fontWeight: 800, mb: 1, color: 'text.primary' }}>
           Create an account
         </Typography>
-        <Typography variant="body2" sx={{ color: '#64748b' }}>
+        <Typography variant="body2" sx={{ color: 'text.secondary' }}>
           Sign up to monitor blockchain analytics and credit metrics
         </Typography>
       </Box>
@@ -221,7 +220,7 @@ export const SignupForm: React.FC = () => {
           {values.password && (
             <Box sx={{ mt: -1, mb: 1 }}>
               <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 0.5 }}>
-                <Typography variant="caption" sx={{ color: '#64748b', fontWeight: 500 }}>
+                <Typography variant="caption" sx={{ color: 'text.secondary', fontWeight: 500 }}>
                   Password Strength:
                 </Typography>
                 <Typography variant="caption" sx={{ color: passwordStrength.color, fontWeight: 700 }}>
@@ -234,7 +233,7 @@ export const SignupForm: React.FC = () => {
                 sx={{ 
                   height: 6, 
                   borderRadius: 3, 
-                  backgroundColor: '#e2e8f0',
+                  backgroundColor: 'action.hover',
                   '& .MuiLinearProgress-bar': {
                     backgroundColor: passwordStrength.color,
                     borderRadius: 3
@@ -294,12 +293,12 @@ export const SignupForm: React.FC = () => {
               />
             }
             label={
-              <Typography variant="body2" sx={{ color: '#475569', userSelect: 'none' }}>
+              <Typography variant="body2" sx={{ color: 'text.secondary', userSelect: 'none' }}>
                 I agree to the{' '}
                 <MuiLink 
                   component={Link}
                   to="/terms"
-                  sx={{ color: '#0284c7', textDecoration: 'none', fontWeight: 600, '&:hover': { textDecoration: 'underline' } }}
+                  sx={{ color: 'primary.main', textDecoration: 'none', fontWeight: 600, '&:hover': { textDecoration: 'underline' } }}
                 >
                   Terms of Service
                 </MuiLink>{' '}
@@ -307,7 +306,7 @@ export const SignupForm: React.FC = () => {
                 <MuiLink 
                   component={Link}
                   to="/privacy"
-                  sx={{ color: '#0284c7', textDecoration: 'none', fontWeight: 600, '&:hover': { textDecoration: 'underline' } }}
+                  sx={{ color: 'primary.main', textDecoration: 'none', fontWeight: 600, '&:hover': { textDecoration: 'underline' } }}
                 >
                   Privacy Policy
                 </MuiLink>
@@ -321,18 +320,14 @@ export const SignupForm: React.FC = () => {
             variant="contained"
             disabled={isSubmitting || !isValid || !acceptTerms}
             fullWidth
-            sx={{
-              py: 1.5,
-              borderRadius: '10px',
-              textTransform: 'none',
-              fontSize: '16px',
-              fontWeight: 600,
-              boxShadow: '0 4px 12px rgba(2, 132, 199, 0.2)',
-              background: 'linear-gradient(135deg, #0284c7 0%, #0369a1 100%)',
-              '&:hover': {
-                background: 'linear-gradient(135deg, #0369a1 0%, #075985 100%)',
-              }
-            }}
+              sx={{
+                py: 1.5,
+                borderRadius: '10px',
+                textTransform: 'none',
+                fontSize: '16px',
+                fontWeight: 600,
+                boxShadow: (theme) => theme.shadows[4],
+              }}
           >
             {isSubmitting ? (
               <CircularProgress size={24} sx={{ color: 'white' }} />
@@ -342,13 +337,13 @@ export const SignupForm: React.FC = () => {
           </Button>
 
           <Box sx={{ textAlign: 'center', mt: 2 }}>
-            <Typography variant="body2" sx={{ color: '#64748b' }}>
+            <Typography variant="body2" sx={{ color: 'text.secondary' }}>
               Already have an account?{' '}
               <MuiLink
                 component={Link}
                 to="/login"
                 sx={{
-                  color: '#0284c7',
+                  color: 'primary.main',
                   textDecoration: 'none',
                   fontWeight: 600,
                   '&:hover': { textDecoration: 'underline' }

--- a/frontend/src/components/charts/DistributionChart.tsx
+++ b/frontend/src/components/charts/DistributionChart.tsx
@@ -7,7 +7,7 @@ import {
   Tooltip,
   Legend
 } from 'recharts';
-import { Paper, Typography, Box } from '@mui/material';
+import { Paper, Typography, Box, useTheme } from '@mui/material';
 
 interface DistributionChartProps {
   data: Record<string, number>;
@@ -17,6 +17,7 @@ interface DistributionChartProps {
 const COLORS = ['#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#8B5CF6'];
 
 export const DistributionChart: React.FC<DistributionChartProps> = ({ data, title }) => {
+  const theme = useTheme();
   const chartData = Object.entries(data).map(([name, value]) => ({ name, value }));
 
   return (
@@ -44,10 +45,18 @@ export const DistributionChart: React.FC<DistributionChartProps> = ({ data, titl
               contentStyle={{ 
                 borderRadius: '8px', 
                 border: 'none', 
-                boxShadow: '0 4px 6px -1px rgb(0 0 0 / 0.1)' 
+                boxShadow: '0 4px 6px -1px rgb(0 0 0 / 0.1)',
+                backgroundColor: theme.palette.background.paper,
+                color: theme.palette.text.primary,
               }}
             />
-            <Legend verticalAlign="bottom" height={36}/>
+            <Legend
+              verticalAlign="bottom"
+              height={36}
+              formatter={(value) => (
+                <span style={{ color: theme.palette.text.secondary }}>{value}</span>
+              )}
+            />
           </PieChart>
         </ResponsiveContainer>
       </Box>

--- a/frontend/src/components/charts/UsageChart.tsx
+++ b/frontend/src/components/charts/UsageChart.tsx
@@ -8,7 +8,7 @@ import {
   AreaChart,
   Area,
 } from 'recharts';
-import { Box, Typography, Paper } from '@mui/material';
+import { Box, Typography, Paper, useTheme } from '@mui/material';
 
 interface UsageChartProps {
   data: Array<{ date: string; value: number }>;
@@ -17,6 +17,7 @@ interface UsageChartProps {
 }
 
 export const UsageChart: React.FC<UsageChartProps> = ({ data, forecast, title }) => {
+  const theme = useTheme();
   const combinedData = [...data, ...(forecast || []).map(f => ({ ...f, isForecast: true }))];
 
   return (
@@ -29,37 +30,39 @@ export const UsageChart: React.FC<UsageChartProps> = ({ data, forecast, title })
           <AreaChart data={combinedData}>
             <defs>
               <linearGradient id="colorValue" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="5%" stopColor="#3B82F6" stopOpacity={0.8}/>
-                <stop offset="95%" stopColor="#3B82F6" stopOpacity={0}/>
+                <stop offset="5%" stopColor={theme.palette.primary.main} stopOpacity={0.8}/>
+                <stop offset="95%" stopColor={theme.palette.primary.main} stopOpacity={0}/>
               </linearGradient>
               <linearGradient id="colorForecast" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="5%" stopColor="#10B981" stopOpacity={0.8}/>
-                <stop offset="95%" stopColor="#10B981" stopOpacity={0}/>
+                <stop offset="5%" stopColor={theme.palette.success.main} stopOpacity={0.8}/>
+                <stop offset="95%" stopColor={theme.palette.success.main} stopOpacity={0}/>
               </linearGradient>
             </defs>
-            <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#E5E7EB" />
+            <CartesianGrid strokeDasharray="3 3" vertical={false} stroke={theme.palette.divider} />
             <XAxis 
               dataKey="date" 
               axisLine={false}
               tickLine={false}
-              tick={{ fill: '#6B7280', fontSize: 12 }}
+              tick={{ fill: theme.palette.text.secondary, fontSize: 12 }}
             />
             <YAxis 
               axisLine={false}
               tickLine={false}
-              tick={{ fill: '#6B7280', fontSize: 12 }}
+              tick={{ fill: theme.palette.text.secondary, fontSize: 12 }}
             />
             <Tooltip 
               contentStyle={{ 
                 borderRadius: '8px', 
                 border: 'none', 
-                boxShadow: '0 4px 6px -1px rgb(0 0 0 / 0.1)' 
+                boxShadow: '0 4px 6px -1px rgb(0 0 0 / 0.1)',
+                backgroundColor: theme.palette.background.paper,
+                color: theme.palette.text.primary,
               }}
             />
             <Area 
               type="monotone" 
               dataKey="value" 
-              stroke="#3B82F6" 
+              stroke={theme.palette.primary.main} 
               strokeWidth={3}
               fillOpacity={1} 
               fill="url(#colorValue)" 

--- a/frontend/src/components/settings/AccountSettings.tsx
+++ b/frontend/src/components/settings/AccountSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Box,
   Typography,
@@ -16,6 +16,7 @@ import {
 } from '@mui/material';
 import { useFormValidation } from '../../hooks/useFormValidation';
 import { ValidationRules } from '@chenaikit/core';
+import { useThemeMode } from '../../contexts/ThemeContext';
 
 interface AccountSettingsProps {
   user: {
@@ -33,6 +34,7 @@ export const AccountSettings: React.FC<AccountSettingsProps> = ({
   onUpdateAccount,
   onDeleteAccount
 }) => {
+  const { setTheme } = useThemeMode();
   const [isSaving, setIsSaving] = useState(false);
   const [saveSuccess, setSaveSuccess] = useState(false);
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
@@ -71,6 +73,12 @@ export const AccountSettings: React.FC<AccountSettingsProps> = ({
     validateOnChange: true,
     validateOnBlur: true
   });
+
+  useEffect(() => {
+    if (values.theme === 'light' || values.theme === 'dark' || values.theme === 'system') {
+      setTheme(values.theme);
+    }
+  }, [values.theme, setTheme]);
 
   const handleDeleteAccount = async () => {
     if (deleteEmail !== user.email) return;
@@ -178,7 +186,7 @@ export const AccountSettings: React.FC<AccountSettingsProps> = ({
           <Typography variant="h6" sx={{ fontWeight: 700, mb: 1, color: 'error.main' }}>
             Danger Zone
           </Typography>
-          <Typography variant="body2" sx={{ color: '#64748b', mb: 3 }}>
+          <Typography variant="body2" sx={{ color: 'text.secondary', mb: 3 }}>
             Once you delete your account, there is no going back. Please be certain.
           </Typography>
 
@@ -197,7 +205,7 @@ export const AccountSettings: React.FC<AccountSettingsProps> = ({
           Delete Account
         </DialogTitle>
         <DialogContent>
-          <Typography variant="body2" sx={{ mb: 3, color: '#475569' }}>
+          <Typography variant="body2" sx={{ mb: 3, color: 'text.secondary' }}>
             This action cannot be undone. To confirm, please type your email address:{' '}
             <strong>{user.email}</strong>
           </Typography>

--- a/frontend/src/components/settings/ApiKeysSettings.tsx
+++ b/frontend/src/components/settings/ApiKeysSettings.tsx
@@ -131,7 +131,7 @@ export const ApiKeysSettings: React.FC<ApiKeysSettingsProps> = ({
                 <Typography variant="h6" sx={{ fontWeight: 700 }}>
                   API Keys
                 </Typography>
-                <Typography variant="body2" sx={{ color: '#64748b' }}>
+                <Typography variant="body2" sx={{ color: 'text.secondary' }}>
                   Manage your API keys for external access
                 </Typography>
               </Box>
@@ -150,11 +150,11 @@ export const ApiKeysSettings: React.FC<ApiKeysSettingsProps> = ({
 
           {apiKeys.length === 0 ? (
             <Box sx={{ textAlign: 'center', py: 6 }}>
-              <VpnKeyIcon sx={{ fontSize: 48, color: '#cbd5e1', mb: 2 }} />
-              <Typography variant="body1" sx={{ color: '#64748b', mb: 2 }}>
+              <VpnKeyIcon sx={{ fontSize: 48, color: 'text.disabled', mb: 2 }} />
+              <Typography variant="body1" sx={{ color: 'text.secondary', mb: 2 }}>
                 No API keys yet
               </Typography>
-              <Typography variant="caption" sx={{ color: '#94a3b8' }}>
+              <Typography variant="caption" sx={{ color: 'text.disabled' }}>
                 Create your first API key to start integrating with external services
               </Typography>
             </Box>
@@ -164,7 +164,8 @@ export const ApiKeysSettings: React.FC<ApiKeysSettingsProps> = ({
                 <ListItem
                   key={apiKey.id}
                   sx={{
-                    borderBottom: '1px solid #f1f5f9',
+                    borderBottom: 1,
+                    borderColor: 'divider',
                     py: 2,
                     '&:last-child': { borderBottom: 'none' },
                     flexDirection: 'column',
@@ -176,13 +177,13 @@ export const ApiKeysSettings: React.FC<ApiKeysSettingsProps> = ({
                       primary={apiKey.name}
                       secondary={
                         <Box component="span" sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
-                          <Typography variant="caption" sx={{ color: '#94a3b8' }}>
+                          <Typography variant="caption" sx={{ color: 'text.disabled' }}>
                             Created: {new Date(apiKey.createdAt).toLocaleDateString()}
                           </Typography>
                           {apiKey.lastUsed && (
                             <>
-                              <Box component="span" sx={{ color: '#cbd5e1' }}>•</Box>
-                              <Typography variant="caption" sx={{ color: '#94a3b8' }}>
+                              <Box component="span" sx={{ color: 'text.disabled' }}>•</Box>
+                              <Typography variant="caption" sx={{ color: 'text.disabled' }}>
                                 Last used: {new Date(apiKey.lastUsed).toLocaleDateString()}
                               </Typography>
                             </>
@@ -237,11 +238,11 @@ export const ApiKeysSettings: React.FC<ApiKeysSettingsProps> = ({
                       mt: 1,
                       px: 2,
                       py: 1,
-                      backgroundColor: '#f8fafc',
+                      bgcolor: 'action.hover',
                       borderRadius: 1,
                       fontFamily: 'monospace',
                       fontSize: '0.875rem',
-                      color: '#475569',
+                      color: 'text.primary',
                       width: '100%'
                     }}
                   >
@@ -254,12 +255,12 @@ export const ApiKeysSettings: React.FC<ApiKeysSettingsProps> = ({
         </CardContent>
       </Card>
 
-      <Card variant="outlined" sx={{ borderRadius: 2, backgroundColor: '#fffbeb' }}>
+      <Card variant="outlined" sx={{ borderRadius: 2, bgcolor: 'warning.light' }}>
         <CardContent>
-          <Typography variant="body2" sx={{ fontWeight: 600, color: '#92400e', mb: 1 }}>
-            Security Notice
+          <Typography variant="body2" sx={{ fontWeight: 600, color: 'warning.dark', mb: 1 }}>
+            Security Information
           </Typography>
-          <Typography variant="body2" sx={{ color: '#a16207' }}>
+          <Typography variant="body2" sx={{ color: 'warning.dark' }}>
             Your API keys carry significant privileges. Keep them secure and never share them in public repositories or client-side code.
           </Typography>
         </CardContent>

--- a/frontend/src/components/settings/NotificationSettings.tsx
+++ b/frontend/src/components/settings/NotificationSettings.tsx
@@ -100,7 +100,7 @@ export const NotificationSettings: React.FC<NotificationSettingsProps> = ({
               }
               label="Email Notifications"
             />
-            <Typography variant="caption" sx={{ color: '#64748b', ml: 6, mb: 2 }}>
+            <Typography variant="caption" sx={{ color: 'text.secondary', ml: 6, mb: 2 }}>
               Receive notifications via email
             </Typography>
 
@@ -115,7 +115,7 @@ export const NotificationSettings: React.FC<NotificationSettingsProps> = ({
               }
               label="Push Notifications"
             />
-            <Typography variant="caption" sx={{ color: '#64748b', ml: 6, mb: 2 }}>
+            <Typography variant="caption" sx={{ color: 'text.secondary', ml: 6, mb: 2 }}>
               Receive push notifications in your browser
             </Typography>
 
@@ -130,7 +130,7 @@ export const NotificationSettings: React.FC<NotificationSettingsProps> = ({
               }
               label="Transaction Alerts"
             />
-            <Typography variant="caption" sx={{ color: '#64748b', ml: 6, mb: 2 }}>
+            <Typography variant="caption" sx={{ color: 'text.secondary', ml: 6, mb: 2 }}>
               Get notified about new transactions
             </Typography>
 
@@ -145,7 +145,7 @@ export const NotificationSettings: React.FC<NotificationSettingsProps> = ({
               }
               label="Score Changes"
             />
-            <Typography variant="caption" sx={{ color: '#64748b', ml: 6, mb: 2 }}>
+            <Typography variant="caption" sx={{ color: 'text.secondary', ml: 6, mb: 2 }}>
               Notifications when your credit score changes
             </Typography>
 
@@ -160,7 +160,7 @@ export const NotificationSettings: React.FC<NotificationSettingsProps> = ({
               }
               label="Price Alerts"
             />
-            <Typography variant="caption" sx={{ color: '#64748b', ml: 6, mb: 2 }}>
+            <Typography variant="caption" sx={{ color: 'text.secondary', ml: 6, mb: 2 }}>
               Alerts for cryptocurrency price changes
             </Typography>
 
@@ -175,7 +175,7 @@ export const NotificationSettings: React.FC<NotificationSettingsProps> = ({
               }
               label="Security Alerts"
             />
-            <Typography variant="caption" sx={{ color: '#64748b', ml: 6, mb: 2 }}>
+            <Typography variant="caption" sx={{ color: 'text.secondary', ml: 6, mb: 2 }}>
               Important security notifications (login attempts, password changes)
             </Typography>
 
@@ -190,7 +190,7 @@ export const NotificationSettings: React.FC<NotificationSettingsProps> = ({
               }
               label="Weekly Report"
             />
-            <Typography variant="caption" sx={{ color: '#64748b', ml: 6, mb: 2 }}>
+            <Typography variant="caption" sx={{ color: 'text.secondary', ml: 6, mb: 2 }}>
               Receive a weekly summary of your activity
             </Typography>
 
@@ -205,7 +205,7 @@ export const NotificationSettings: React.FC<NotificationSettingsProps> = ({
               }
               label="Marketing Emails"
             />
-            <Typography variant="caption" sx={{ color: '#64748b', ml: 6 }}>
+            <Typography variant="caption" sx={{ color: 'text.secondary', ml: 6 }}>
               Product updates, promotions, and newsletters
             </Typography>
           </Box>

--- a/frontend/src/components/settings/SecuritySettings.tsx
+++ b/frontend/src/components/settings/SecuritySettings.tsx
@@ -243,7 +243,7 @@ export const SecuritySettings: React.FC<SecuritySettingsProps> = ({
                 <Typography variant="h6" sx={{ fontWeight: 700 }}>
                   Two-Factor Authentication
                 </Typography>
-                <Typography variant="body2" sx={{ color: '#64748b' }}>
+                <Typography variant="body2" sx={{ color: 'text.secondary' }}>
                   Add an extra layer of security to your account
                 </Typography>
               </Box>
@@ -286,16 +286,16 @@ export const SecuritySettings: React.FC<SecuritySettingsProps> = ({
           </Box>
 
           {sessions.length === 0 ? (
-            <Typography variant="body2" sx={{ color: '#64748b' }}>
-              No active sessions
-            </Typography>
+                  <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                    Active Sessions
+                  </Typography>
           ) : (
             <List>
               {sessions.map((session) => (
                 <ListItem
                   key={session.id}
                   sx={{
-                    borderBottom: '1px solid #f1f5f9',
+                    borderBottom: 1, borderColor: 'divider',
                     '&:last-child': { borderBottom: 'none' }
                   }}
                   secondaryAction={
@@ -345,7 +345,7 @@ export const SecuritySettings: React.FC<SecuritySettingsProps> = ({
           </Box>
 
           {loginHistory.length === 0 ? (
-            <Typography variant="body2" sx={{ color: '#64748b' }}>
+            <Typography variant="body2" sx={{ color: 'text.secondary' }}>
               No login history available
             </Typography>
           ) : (
@@ -354,7 +354,7 @@ export const SecuritySettings: React.FC<SecuritySettingsProps> = ({
                 <ListItem
                   key={login.id}
                   sx={{
-                    borderBottom: '1px solid #f1f5f9',
+                    borderBottom: 1, borderColor: 'divider',
                     '&:last-child': { borderBottom: 'none' }
                   }}
                 >

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -1,0 +1,100 @@
+import React, { createContext, useContext, useState, useEffect, useCallback, useMemo } from 'react';
+import { ThemeProvider as MuiThemeProvider, CssBaseline } from '@mui/material';
+import { lightTheme } from '../themes/lightTheme';
+import { darkTheme } from '../themes/darkTheme';
+
+type ThemeMode = 'light' | 'dark';
+type UserPreference = ThemeMode | 'system';
+
+interface ThemeContextType {
+  mode: ThemeMode;
+  userPreference: UserPreference;
+  setTheme: (preference: UserPreference) => void;
+  toggleTheme: () => void;
+}
+
+const THEME_STORAGE_KEY = 'chenaikit_theme';
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+const getSystemPreference = (): ThemeMode => {
+  if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    return 'dark';
+  }
+  return 'light';
+};
+
+function getInitialPreference(): UserPreference {
+  try {
+    const stored = localStorage.getItem(THEME_STORAGE_KEY);
+    if (stored === 'light' || stored === 'dark' || stored === 'system') {
+      return stored;
+    }
+  } catch {
+    // localStorage not available
+  }
+  return 'system';
+}
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [userPreference, setUserPreference] = useState<UserPreference>(getInitialPreference);
+  const [systemPreference, setSystemPreference] = useState<ThemeMode>(getSystemPreference);
+
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const handler = (e: MediaQueryListEvent) => setSystemPreference(e.matches ? 'dark' : 'light');
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(THEME_STORAGE_KEY, userPreference);
+    } catch {
+      // localStorage not available
+    }
+  }, [userPreference]);
+
+  const mode = userPreference === 'system' ? systemPreference : userPreference;
+
+  const setTheme = useCallback((preference: UserPreference) => {
+    setUserPreference(preference);
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    const next = mode === 'light' ? 'dark' : 'light';
+    setUserPreference(next);
+  }, [mode]);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 'd') {
+        e.preventDefault();
+        toggleTheme();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [toggleTheme]);
+
+  const activeTheme = mode === 'light' ? lightTheme : darkTheme;
+
+  const contextValue = useMemo(() => ({ mode, userPreference, setTheme, toggleTheme }), [mode, userPreference, setTheme, toggleTheme]);
+
+  return (
+    <ThemeContext.Provider value={contextValue}>
+      <MuiThemeProvider theme={activeTheme}>
+        <CssBaseline />
+        {children}
+      </MuiThemeProvider>
+    </ThemeContext.Provider>
+  );
+};
+
+export const useThemeMode = () => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useThemeMode must be used within a ThemeProvider');
+  }
+  return context;
+};

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -20,7 +20,7 @@ export const Login: React.FC = () => {
   const isMdUp = useMediaQuery(theme.breakpoints.up('md'));
 
   return (
-    <Grid container sx={{ minHeight: '100vh', backgroundColor: '#f8fafc' }}>
+    <Grid container sx={{ minHeight: '100vh', bgcolor: 'background.default' }}>
       {/* Left panel - Branding & Features (hidden on mobile) */}
       {isMdUp && (
         <Grid 

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -84,7 +84,7 @@ export const Profile: React.FC<ProfilePageProps> = ({
   const [activeTab, setActiveTab] = useState(0);
 
   return (
-    <Box sx={{ minHeight: '100vh', backgroundColor: '#f8fafc', p: { xs: 2, md: 4 } }}>
+    <Box sx={{ minHeight: '100vh', bgcolor: 'background.default', p: { xs: 2, md: 4 } }}>
       <Box sx={{ maxWidth: 1200, mx: 'auto' }}>
         <ProfileHeader user={user} stats={stats} onUpdateProfile={onUpdateProfile} />
 
@@ -94,7 +94,8 @@ export const Profile: React.FC<ProfilePageProps> = ({
             onChange={(_, newValue) => setActiveTab(newValue)}
             variant="fullWidth"
             sx={{
-              borderBottom: '1px solid #e5e7eb',
+              borderBottom: 1,
+              borderColor: 'divider',
               '& .MuiTab-root': {
                 fontWeight: 600,
                 textTransform: 'none'
@@ -108,46 +109,47 @@ export const Profile: React.FC<ProfilePageProps> = ({
 
           <Box sx={{ p: 3 }}>
             <TabPanel value={activeTab} index={0}>
-              <Typography variant="h6" sx={{ fontWeight: 700, mb: 3, color: '#0f172a' }}>
+              <Typography variant="h6" sx={{ fontWeight: 700, mb: 3, color: 'text.primary' }}>
                 Recent Activity
               </Typography>
               {activity.length === 0 ? (
                 <Box sx={{ textAlign: 'center', py: 6 }}>
-                  <HistoryIcon sx={{ fontSize: 48, color: '#cbd5e1', mb: 2 }} />
-                  <Typography variant="body1" sx={{ color: '#64748b' }}>
+                  <HistoryIcon sx={{ fontSize: 48, color: 'text.disabled', mb: 2 }} />
+                  <Typography variant="body1" sx={{ color: 'text.secondary' }}>
                     No recent activity
                   </Typography>
                 </Box>
               ) : (
                 <List>
                   {activity.map((item) => (
-                    <ListItem
-                      key={item.id}
-                      sx={{
-                        borderBottom: '1px solid #f1f5f9',
-                        py: 2,
-                        '&:last-child': { borderBottom: 'none' }
-                      }}
-                    >
-                      <ListItemIcon>{getActivityIcon(item.type)}</ListItemIcon>
-                      <ListItemText
-                        primary={item.title}
-                        secondary={
-                          <Box component="span">
-                            <Typography variant="body2" component="span" sx={{ color: '#475569' }}>
-                              {item.description}
-                            </Typography>
-                            <Typography
-                              variant="caption"
-                              component="span"
-                              sx={{ display: 'block', color: '#94a3b8', mt: 0.5 }}
-                            >
-                              {new Date(item.timestamp).toLocaleString()}
-                            </Typography>
-                          </Box>
-                        }
-                      />
-                    </ListItem>
+                      <ListItem
+                        key={item.id}
+                        sx={{
+                          borderBottom: 1,
+                          borderColor: 'divider',
+                          py: 2,
+                          '&:last-child': { borderBottom: 'none' }
+                        }}
+                      >
+                        <ListItemIcon>{getActivityIcon(item.type)}</ListItemIcon>
+                        <ListItemText
+                          primary={item.title}
+                          secondary={
+                            <Box component="span">
+                              <Typography variant="body2" component="span" sx={{ color: 'text.secondary' }}>
+                                {item.description}
+                              </Typography>
+                              <Typography
+                                variant="caption"
+                                component="span"
+                                sx={{ display: 'block', color: 'text.disabled', mt: 0.5 }}
+                              >
+                                {new Date(item.timestamp).toLocaleString()}
+                              </Typography>
+                            </Box>
+                          }
+                        />
+                      </ListItem>
                   ))}
                 </List>
               )}
@@ -163,7 +165,7 @@ export const Profile: React.FC<ProfilePageProps> = ({
                       </Typography>
                       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
                         <Box>
-                          <Typography variant="caption" sx={{ color: '#64748b' }}>
+                          <Typography variant="caption" sx={{ color: 'text.secondary' }}>
                             Email
                           </Typography>
                           <Typography variant="body1" sx={{ fontWeight: 500 }}>
@@ -171,7 +173,7 @@ export const Profile: React.FC<ProfilePageProps> = ({
                           </Typography>
                         </Box>
                         <Box>
-                          <Typography variant="caption" sx={{ color: '#64748b' }}>
+                          <Typography variant="caption" sx={{ color: 'text.secondary' }}>
                             Role
                           </Typography>
                           <Typography variant="body1" sx={{ fontWeight: 500, textTransform: 'capitalize' }}>
@@ -179,10 +181,10 @@ export const Profile: React.FC<ProfilePageProps> = ({
                           </Typography>
                         </Box>
                         {user.createdAt && (
-                          <Box>
-                            <Typography variant="caption" sx={{ color: '#64748b' }}>
-                              Member Since
-                            </Typography>
+                        <Box>
+                          <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                            Member Since
+                          </Typography>
                             <Typography variant="body1" sx={{ fontWeight: 500 }}>
                               {new Date(user.createdAt).toLocaleDateString()}
                             </Typography>
@@ -225,10 +227,10 @@ export const Profile: React.FC<ProfilePageProps> = ({
                   <Grid item xs={12} sm={4}>
                     <Card variant="outlined" sx={{ borderRadius: 2, textAlign: 'center', p: 3 }}>
                       <CreditCardIcon sx={{ fontSize: 40, color: '#38bdf8', mb: 1 }} />
-                      <Typography variant="h3" sx={{ fontWeight: 700, color: '#0f172a' }}>
+                      <Typography variant="h3" sx={{ fontWeight: 700, color: 'text.primary' }}>
                         {stats.transactions.toLocaleString()}
                       </Typography>
-                      <Typography variant="body2" sx={{ color: '#64748b' }}>
+                      <Typography variant="body2" sx={{ color: 'text.secondary' }}>
                         Total Transactions
                       </Typography>
                     </Card>
@@ -238,10 +240,10 @@ export const Profile: React.FC<ProfilePageProps> = ({
                   <Grid item xs={12} sm={4}>
                     <Card variant="outlined" sx={{ borderRadius: 2, textAlign: 'center', p: 3 }}>
                       <TrendingUpIcon sx={{ fontSize: 40, color: '#22c55e', mb: 1 }} />
-                      <Typography variant="h3" sx={{ fontWeight: 700, color: '#0f172a' }}>
+                      <Typography variant="h3" sx={{ fontWeight: 700, color: 'text.primary' }}>
                         {stats.score}
                       </Typography>
-                      <Typography variant="body2" sx={{ color: '#64748b' }}>
+                      <Typography variant="body2" sx={{ color: 'text.secondary' }}>
                         Credit Score
                       </Typography>
                     </Card>
@@ -251,10 +253,10 @@ export const Profile: React.FC<ProfilePageProps> = ({
                   <Grid item xs={12} sm={4}>
                     <Card variant="outlined" sx={{ borderRadius: 2, textAlign: 'center', p: 3 }}>
                       <HistoryIcon sx={{ fontSize: 40, color: '#a855f7', mb: 1 }} />
-                      <Typography variant="h3" sx={{ fontWeight: 700, color: '#0f172a' }}>
+                      <Typography variant="h3" sx={{ fontWeight: 700, color: 'text.primary' }}>
                         {stats.activeDays}
                       </Typography>
-                      <Typography variant="body2" sx={{ color: '#64748b' }}>
+                      <Typography variant="body2" sx={{ color: 'text.secondary' }}>
                         Active Days
                       </Typography>
                     </Card>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -111,7 +111,7 @@ export const Settings: React.FC<SettingsPageProps> = ({
   const [activeTab, setActiveTab] = useState(0);
 
   return (
-    <Box sx={{ minHeight: '100vh', backgroundColor: '#f8fafc', p: { xs: 2, md: 4 } }}>
+    <Box sx={{ minHeight: '100vh', bgcolor: 'background.default', p: { xs: 2, md: 4 } }}>
       <Box sx={{ maxWidth: 1000, mx: 'auto' }}>
         <Breadcrumbs sx={{ mb: 2 }}>
           <Link component={RouterLink} to="/" underline="hover" color="inherit">
@@ -121,8 +121,8 @@ export const Settings: React.FC<SettingsPageProps> = ({
         </Breadcrumbs>
 
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 4 }}>
-          <SettingsIcon sx={{ fontSize: 32, color: '#0f172a' }} />
-          <Typography variant="h4" sx={{ fontWeight: 700, color: '#0f172a' }}>
+          <SettingsIcon sx={{ fontSize: 32, color: 'text.primary' }} />
+          <Typography variant="h4" sx={{ fontWeight: 700, color: 'text.primary' }}>
             Settings
           </Typography>
         </Box>
@@ -134,7 +134,8 @@ export const Settings: React.FC<SettingsPageProps> = ({
             variant="scrollable"
             scrollButtons="auto"
             sx={{
-              borderBottom: '1px solid #e5e7eb',
+              borderBottom: 1,
+              borderColor: 'divider',
               '& .MuiTab-root': {
                 fontWeight: 600,
                 textTransform: 'none',

--- a/frontend/src/pages/Signup.tsx
+++ b/frontend/src/pages/Signup.tsx
@@ -20,7 +20,7 @@ export const Signup: React.FC = () => {
   const isMdUp = useMediaQuery(theme.breakpoints.up('md'));
 
   return (
-    <Grid container sx={{ minHeight: '100vh', backgroundColor: '#f8fafc' }}>
+    <Grid container sx={{ minHeight: '100vh', bgcolor: 'background.default' }}>
       {/* Left panel - Branding & Features (hidden on mobile) */}
       {isMdUp && (
         <Grid 

--- a/frontend/src/themes/darkTheme.ts
+++ b/frontend/src/themes/darkTheme.ts
@@ -1,0 +1,81 @@
+import { createTheme } from '@mui/material/styles';
+
+export const darkTheme = createTheme({
+  palette: {
+    mode: 'dark',
+    primary: {
+      main: '#38bdf8',
+      light: '#7dd3fc',
+      dark: '#0284c7',
+      contrastText: '#0f172a',
+    },
+    secondary: {
+      main: '#a78bfa',
+      light: '#c4b5fd',
+      dark: '#8b5cf6',
+      contrastText: '#0f172a',
+    },
+    error: {
+      main: '#f87171',
+      light: '#fca5a5',
+      dark: '#ef4444',
+    },
+    warning: {
+      main: '#fbbf24',
+      light: '#fde68a',
+      dark: '#f59e0b',
+    },
+    success: {
+      main: '#34d399',
+      light: '#6ee7b7',
+      dark: '#10b981',
+    },
+    info: {
+      main: '#38bdf8',
+      light: '#7dd3fc',
+      dark: '#0ea5e9',
+    },
+    background: {
+      default: '#0f172a',
+      paper: '#1e293b',
+    },
+    text: {
+      primary: '#f1f5f9',
+      secondary: '#94a3b8',
+      disabled: '#64748b',
+    },
+    divider: '#334155',
+  },
+  typography: {
+    fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif',
+    h4: { fontWeight: 700 },
+    h5: { fontWeight: 700 },
+    h6: { fontWeight: 700 },
+    subtitle1: { fontWeight: 600 },
+  },
+  shape: { borderRadius: 8 },
+  components: {
+    MuiCard: {
+      styleOverrides: {
+        root: {
+          borderRadius: 12,
+          backgroundImage: 'none',
+          boxShadow: '0 1px 3px 0 rgb(0 0 0 / 0.3), 0 1px 2px -1px rgb(0 0 0 / 0.3)',
+        },
+      },
+    },
+    MuiPaper: {
+      styleOverrides: { root: { backgroundImage: 'none' } },
+    },
+    MuiButton: {
+      styleOverrides: {
+        root: { textTransform: 'none', fontWeight: 600, borderRadius: 8 },
+      },
+    },
+    MuiCssBaseline: {
+      styleOverrides: {
+        body: { transition: 'background-color 0.3s ease, color 0.3s ease' },
+      },
+    },
+  },
+});

--- a/frontend/src/themes/lightTheme.ts
+++ b/frontend/src/themes/lightTheme.ts
@@ -1,0 +1,80 @@
+import { createTheme } from '@mui/material/styles';
+
+export const lightTheme = createTheme({
+  palette: {
+    mode: 'light',
+    primary: {
+      main: '#0284c7',
+      light: '#38bdf8',
+      dark: '#0369a1',
+      contrastText: '#ffffff',
+    },
+    secondary: {
+      main: '#8b5cf6',
+      light: '#a78bfa',
+      dark: '#7c3aed',
+      contrastText: '#ffffff',
+    },
+    error: {
+      main: '#ef4444',
+      light: '#f87171',
+      dark: '#dc2626',
+    },
+    warning: {
+      main: '#f59e0b',
+      light: '#fbbf24',
+      dark: '#d97706',
+    },
+    success: {
+      main: '#10b981',
+      light: '#34d399',
+      dark: '#059669',
+    },
+    info: {
+      main: '#0ea5e9',
+      light: '#38bdf8',
+      dark: '#0284c7',
+    },
+    background: {
+      default: '#f8fafc',
+      paper: '#ffffff',
+    },
+    text: {
+      primary: '#0f172a',
+      secondary: '#475569',
+      disabled: '#94a3b8',
+    },
+    divider: '#e5e7eb',
+  },
+  typography: {
+    fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif',
+    h4: { fontWeight: 700 },
+    h5: { fontWeight: 700 },
+    h6: { fontWeight: 700 },
+    subtitle1: { fontWeight: 600 },
+  },
+  shape: { borderRadius: 8 },
+  components: {
+    MuiCard: {
+      styleOverrides: {
+        root: {
+          borderRadius: 12,
+          boxShadow: '0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1)',
+        },
+      },
+    },
+    MuiPaper: {
+      styleOverrides: { root: { backgroundImage: 'none' } },
+    },
+    MuiButton: {
+      styleOverrides: {
+        root: { textTransform: 'none', fontWeight: 600, borderRadius: 8 },
+      },
+    },
+    MuiCssBaseline: {
+      styleOverrides: {
+        body: { transition: 'background-color 0.3s ease, color 0.3s ease' },
+      },
+    },
+  },
+});


### PR DESCRIPTION
closes #145 

All done. Here's a summary of the dark mode implementation:

**Created files:**
- `frontend/src/themes/lightTheme.ts` - Light MUI theme config with existing project color palette
- `frontend/src/themes/darkTheme.ts` - Dark MUI theme config with adjusted palette for dark backgrounds
- `frontend/src/contexts/ThemeContext.tsx` - Theme context with localStorage persistence, system preference detection (`prefers-color-scheme`), keyboard shortcut (Ctrl/Cmd+D), and toggle
- `frontend/src/components/ThemeToggle.tsx` - Sun/moon icon button that toggles between light/dark modes

**Modified files:**
- `App.tsx` - Wrapped app with `ThemeProvider`, added `ThemeToggle` to header, updated stub pages (ForgotPassword, Terms, Privacy) and footer with theme-aware colors
- All `pages/` (Login, Signup, Profile, Settings) - Replaced hardcoded hex colors with MUI theme token references (`text.primary`, `text.secondary`, `background.default`, `divider`, etc.)
- `components/AnalyticsDashboard.tsx` - Theme-aware backgrounds and text colors
- `components/auth/LoginForm.tsx` / `SignupForm.tsx` - Theme-aware colors, removed hardcoded gradients
- `components/charts/UsageChart.tsx` / `DistributionChart.tsx` - Chart colors adapt via `useTheme()`
- `components/settings/*` - Theme-aware colors; `AccountSettings.tsx` integrates with `ThemeContext` so the dropdown actually changes the theme
- `components/settings/ApiKeysSettings.tsx` / `NotificationSettings.tsx` / `SecuritySettings.tsx` - Fixed all hardcoded colors
