### PR TITLE
feat(frontend): add form validation library integration (Issue #157)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "@chenaikit/core": "workspace:*",
     "@emotion/react": "^11.11.0",
     "@emotion/styled": "^11.11.0",
+    "@hookform/resolvers": "3.10.0",
     "@mui/icons-material": "^5.15.0",
     "@mui/material": "^5.15.0",
     "axios": "^1.6.0",
@@ -27,9 +28,11 @@
     "i18next-http-backend": "^2.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-hook-form": "7.54.2",
     "react-i18next": "^13.5.0",
     "react-router-dom": "^6.8.0",
-    "recharts": "^3.2.1"
+    "recharts": "^3.2.1",
+    "zod": "3.24.2"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.0",

--- a/frontend/src/components/forms/FormError.tsx
+++ b/frontend/src/components/forms/FormError.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+export interface FormErrorProps {
+  error?: string;
+  field: string;
+  /** DOM id so input can reference with aria-describedby */
+  id?: string;
+  className?: string;
+}
+
+/**
+ * Accessible inline error message for form fields.
+ * Renders nothing when `error` is falsy.
+ */
+export const FormError: React.FC<FormErrorProps> = ({
+  error,
+  field,
+  id,
+  className = '',
+}) => {
+  if (!error) return null;
+
+  return (
+    <div
+      id={id}
+      className={`form-error ${className}`.trim()}
+      role="alert"
+      aria-live="polite"
+      aria-labelledby={`${field}-label`}
+    >
+      <span className="form-error__icon" aria-hidden="true">
+        ⚠️
+      </span>
+      <span className="form-error__message">{error}</span>
+    </div>
+  );
+};
+
+export default FormError;

--- a/frontend/src/components/forms/FormField.tsx
+++ b/frontend/src/components/forms/FormField.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import {
+  useController,
+  UseControllerProps,
+  FieldValues,
+} from 'react-hook-form';
+import { FormError } from './FormError';
+
+export interface FormFieldProps<T extends FieldValues = FieldValues>
+  extends UseControllerProps<T> {
+  /** Visible label text */
+  label: string;
+  /** One of the standard HTML input types, plus 'textarea' and 'select' */
+  type?: React.HTMLInputTypeAttribute | 'textarea' | 'select';
+  placeholder?: string;
+  disabled?: boolean;
+  /** Options for select fields */
+  options?: Array<{ value: string; label: string }>;
+  className?: string;
+  /** Show validation on change (default true) */
+  validateOnChange?: boolean;
+}
+
+/**
+ * Generic controlled `FormField` powered by React Hook Form.
+ *
+ * Supports: text, email, password, number, tel, url, textarea, select.
+ * Validates in real-time (on change + on blur) and shows inline errors.
+ */
+export function FormField<T extends FieldValues = FieldValues>({
+  label,
+  type = 'text',
+  placeholder,
+  disabled = false,
+  options = [],
+  className = '',
+  name,
+  control,
+  rules: validationRules,
+  defaultValue,
+}: FormFieldProps<T>) {
+  const {
+    field,
+    fieldState: { error, isTouched },
+  } = useController<T>({ name, control, rules: validationRules, defaultValue });
+
+  const id = `field-${name as string}`;
+  const errorId = `error-${name as string}`;
+  const hasError = !!error;
+
+  const baseClass = [
+    'form-field__input',
+    hasError ? 'form-field__input--error' : '',
+    disabled ? 'form-field__input--disabled' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const renderInput = () => {
+    if (type === 'textarea') {
+      return (
+        <textarea
+          {...field}
+          id={id}
+          placeholder={placeholder}
+          disabled={disabled}
+          rows={4}
+          aria-invalid={hasError}
+          aria-describedby={hasError ? errorId : undefined}
+          className={`${baseClass} form-field__textarea`}
+        />
+      );
+    }
+
+    if (type === 'select') {
+      return (
+        <select
+          {...field}
+          id={id}
+          disabled={disabled}
+          aria-invalid={hasError}
+          aria-describedby={hasError ? errorId : undefined}
+          className={`${baseClass} form-field__select`}
+        >
+          {placeholder && (
+            <option value="" disabled>
+              {placeholder}
+            </option>
+          )}
+          {options.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      );
+    }
+
+    return (
+      <input
+        {...field}
+        id={id}
+        type={type}
+        placeholder={placeholder}
+        disabled={disabled}
+        aria-invalid={hasError}
+        aria-describedby={hasError ? errorId : undefined}
+        className={`${baseClass} form-field__input--${type}`}
+      />
+    );
+  };
+
+  return (
+    <div
+      className={[
+        'form-field',
+        hasError ? 'form-field--error' : '',
+        disabled ? 'form-field--disabled' : '',
+        className,
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <label
+        htmlFor={id}
+        id={`${name as string}-label`}
+        className="form-field__label"
+      >
+        {label}
+        {validationRules?.required && (
+          <span className="form-field__required" aria-label="required">
+            {' '}*
+          </span>
+        )}
+      </label>
+
+      <div className="form-field__input-wrapper">{renderInput()}</div>
+
+      <FormError
+        id={errorId}
+        error={isTouched || hasError ? error?.message : undefined}
+        field={name as string}
+        className="form-field__error"
+      />
+    </div>
+  );
+}
+
+export default FormField;

--- a/frontend/src/components/forms/FormSubmit.tsx
+++ b/frontend/src/components/forms/FormSubmit.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { useFormState, UseFormStateProps, FieldValues } from 'react-hook-form';
+
+export interface FormSubmitProps<T extends FieldValues = FieldValues>
+  extends Pick<UseFormStateProps<T>, 'control'> {
+  /** Button label when idle */
+  label?: string;
+  /** Button label while submitting */
+  labelSubmitting?: string;
+  /** Disable the button when the form is invalid (default true) */
+  disableWhenInvalid?: boolean;
+  className?: string;
+  /** Optional reset handler */
+  onReset?: () => void;
+  /** Label for the optional reset button */
+  resetLabel?: string;
+}
+
+/**
+ * Submit button that:
+ * - is disabled while the form is submitting or invalid,
+ * - shows a "Submitting…" label during async submission,
+ * - optionally renders a Reset button.
+ */
+export function FormSubmit<T extends FieldValues = FieldValues>({
+  control,
+  label = 'Submit',
+  labelSubmitting = 'Submitting…',
+  disableWhenInvalid = true,
+  className = '',
+  onReset,
+  resetLabel = 'Reset',
+}: FormSubmitProps<T>) {
+  const { isSubmitting, isValid } = useFormState({ control });
+
+  const isDisabled = isSubmitting || (disableWhenInvalid && !isValid);
+
+  return (
+    <div className={`form-submit ${className}`.trim()}>
+      <button
+        type="submit"
+        disabled={isDisabled}
+        aria-disabled={isDisabled}
+        aria-busy={isSubmitting}
+        className={[
+          'form-submit__button',
+          isDisabled ? 'form-submit__button--disabled' : '',
+        ]
+          .filter(Boolean)
+          .join(' ')}
+      >
+        {isSubmitting ? labelSubmitting : label}
+      </button>
+
+      {onReset && (
+        <button
+          type="button"
+          onClick={onReset}
+          disabled={isSubmitting}
+          className="form-submit__reset"
+        >
+          {resetLabel}
+        </button>
+      )}
+    </div>
+  );
+}
+
+export default FormSubmit;

--- a/frontend/src/components/forms/__tests__/FormError.test.tsx
+++ b/frontend/src/components/forms/__tests__/FormError.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { FormError } from '../FormError';
+
+describe('forms/FormError', () => {
+  it('renders nothing when error is undefined', () => {
+    render(<FormError error={undefined} field="email" />);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when error is empty string', () => {
+    render(<FormError error="" field="email" />);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('renders the error message', () => {
+    render(<FormError error="Email is required" field="email" />);
+    expect(screen.getByRole('alert')).toHaveTextContent('Email is required');
+  });
+
+  it('applies custom className', () => {
+    render(<FormError error="Oops" field="email" className="my-error" />);
+    expect(screen.getByRole('alert')).toHaveClass('my-error', 'form-error');
+  });
+
+  it('sets aria-live="polite"', () => {
+    render(<FormError error="Oops" field="email" />);
+    expect(screen.getByRole('alert')).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('sets aria-labelledby to field-label id', () => {
+    render(<FormError error="Oops" field="email" />);
+    expect(screen.getByRole('alert')).toHaveAttribute('aria-labelledby', 'email-label');
+  });
+
+  it('sets id prop on the container', () => {
+    render(<FormError error="Oops" field="email" id="error-email" />);
+    expect(screen.getByRole('alert')).toHaveAttribute('id', 'error-email');
+  });
+
+  it('renders warning icon with aria-hidden', () => {
+    render(<FormError error="Oops" field="email" />);
+    const icon = screen.getByText('⚠️');
+    expect(icon).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('renders message in form-error__message span', () => {
+    render(<FormError error="Bad input" field="name" />);
+    const msg = screen.getByText('Bad input');
+    expect(msg).toHaveClass('form-error__message');
+  });
+});

--- a/frontend/src/components/forms/__tests__/FormField.test.tsx
+++ b/frontend/src/components/forms/__tests__/FormField.test.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useForm } from 'react-hook-form';
+import { FormField } from '../FormField';
+
+function renderField(overrides: Partial<React.ComponentProps<typeof FormField>> = {}) {
+  function Wrapper() {
+    const { control } = useForm({ mode: 'onChange' });
+    return (
+      <FormField
+        control={control}
+        name="testField"
+        label="Test Label"
+        {...(overrides as any)}
+      />
+    );
+  }
+  return render(<Wrapper />);
+}
+
+describe('forms/FormField', () => {
+  it('renders label and input', () => {
+    renderField();
+    expect(screen.getByLabelText(/test label/i)).toBeInTheDocument();
+  });
+
+  it('renders required asterisk when rules.required is set', () => {
+    renderField({ rules: { required: 'Required' } });
+    expect(screen.getByText('*')).toBeInTheDocument();
+  });
+
+  it('renders a textarea when type="textarea"', () => {
+    renderField({ type: 'textarea' });
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('renders a select when type="select"', () => {
+    renderField({
+      type: 'select',
+      options: [
+        { value: 'a', label: 'Option A' },
+        { value: 'b', label: 'Option B' },
+      ],
+    });
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+    expect(screen.getByText('Option A')).toBeInTheDocument();
+    expect(screen.getByText('Option B')).toBeInTheDocument();
+  });
+
+  it('renders an input with the given type', () => {
+    renderField({ type: 'email' });
+    expect(screen.getByRole('textbox')).toHaveAttribute('type', 'email');
+  });
+
+  it('renders placeholder text', () => {
+    renderField({ placeholder: 'Enter value here' });
+    expect(screen.getByPlaceholderText('Enter value here')).toBeInTheDocument();
+  });
+
+  it('disables the input when disabled=true', () => {
+    renderField({ disabled: true });
+    expect(screen.getByRole('textbox')).toBeDisabled();
+  });
+
+  it('shows aria-invalid when there is an error', async () => {
+    function Wrapper() {
+      const { control, trigger } = useForm({ mode: 'onChange' });
+      return (
+        <>
+          <FormField
+            control={control}
+            name="email"
+            label="Email"
+            type="email"
+            rules={{ required: 'Email is required' }}
+          />
+          <button onClick={() => trigger('email')}>Validate</button>
+        </>
+      );
+    }
+    render(<Wrapper />);
+    fireEvent.click(screen.getByText('Validate'));
+    await waitFor(() => {
+      expect(screen.getByRole('textbox')).toHaveAttribute('aria-invalid', 'true');
+    });
+  });
+
+  it('shows error message after validation failure', async () => {
+    function Wrapper() {
+      const { control, trigger } = useForm({ mode: 'onChange' });
+      return (
+        <>
+          <FormField
+            control={control}
+            name="email"
+            label="Email"
+            rules={{ required: 'Email is required' }}
+          />
+          <button onClick={() => trigger('email')}>Validate</button>
+        </>
+      );
+    }
+    render(<Wrapper />);
+    fireEvent.click(screen.getByText('Validate'));
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Email is required');
+    });
+  });
+});

--- a/frontend/src/components/forms/__tests__/FormSubmit.test.tsx
+++ b/frontend/src/components/forms/__tests__/FormSubmit.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useForm } from 'react-hook-form';
+import { FormSubmit } from '../FormSubmit';
+
+describe('forms/FormSubmit', () => {
+  it('renders a submit button with default label', () => {
+    function Inner() {
+      const { control } = useForm();
+      return <FormSubmit control={control} />;
+    }
+    render(<Inner />);
+    expect(screen.getByRole('button', { name: /submit/i })).toBeInTheDocument();
+  });
+
+  it('uses custom label', () => {
+    function Inner() {
+      const { control } = useForm();
+      return <FormSubmit control={control} label="Send" />;
+    }
+    render(<Inner />);
+    expect(screen.getByRole('button', { name: /send/i })).toBeInTheDocument();
+  });
+
+  it('renders reset button when onReset is provided', () => {
+    const onReset = jest.fn();
+    function Inner() {
+      const { control } = useForm();
+      return <FormSubmit control={control} onReset={onReset} />;
+    }
+    render(<Inner />);
+    const resetBtn = screen.getByRole('button', { name: /reset/i });
+    expect(resetBtn).toBeInTheDocument();
+    fireEvent.click(resetBtn);
+    expect(onReset).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render reset button when onReset is absent', () => {
+    function Inner() {
+      const { control } = useForm();
+      return <FormSubmit control={control} />;
+    }
+    render(<Inner />);
+    expect(screen.queryByRole('button', { name: /reset/i })).not.toBeInTheDocument();
+  });
+
+  it('applies custom className', () => {
+    function Inner() {
+      const { control } = useForm();
+      return <FormSubmit control={control} className="my-submit" />;
+    }
+    const { container } = render(<Inner />);
+    expect(container.querySelector('.form-submit.my-submit')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/forms/index.ts
+++ b/frontend/src/components/forms/index.ts
@@ -1,0 +1,8 @@
+export { FormField } from './FormField';
+export type { FormFieldProps } from './FormField';
+
+export { FormError } from './FormError';
+export type { FormErrorProps } from './FormError';
+
+export { FormSubmit } from './FormSubmit';
+export type { FormSubmitProps } from './FormSubmit';

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -1,3 +1,11 @@
+// Form validation library (React Hook Form + Zod)
+export { FormField as RHFFormField } from './forms/FormField';
+export type { FormFieldProps as RHFFormFieldProps } from './forms/FormField';
+export { FormError as RHFFormError } from './forms/FormError';
+export type { FormErrorProps as RHFFormErrorProps } from './forms/FormError';
+export { FormSubmit } from './forms/FormSubmit';
+export type { FormSubmitProps } from './forms/FormSubmit';
+
 export { default as CreditScoreCard } from './CreditScoreCard';
 export { default as ScoreHistoryChart } from './ScoreHistoryChart';
 export { default as RiskFactorsList } from './RiskFactorsList';

--- a/frontend/src/validation/__tests__/rules.test.tsx
+++ b/frontend/src/validation/__tests__/rules.test.tsx
@@ -1,0 +1,114 @@
+import { rules } from '../rules';
+
+describe('validation/rules', () => {
+  describe('rules.required', () => {
+    it('accepts a non-empty string', () => {
+      expect(rules.required().safeParse('hello').success).toBe(true);
+    });
+    it('rejects an empty string', () => {
+      expect(rules.required().safeParse('').success).toBe(false);
+    });
+    it('uses custom message', () => {
+      const result = rules.required('Custom msg').safeParse('');
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error.issues[0].message).toBe('Custom msg');
+    });
+  });
+
+  describe('rules.email', () => {
+    it('accepts a valid email', () => {
+      expect(rules.email().safeParse('a@b.com').success).toBe(true);
+    });
+    it('rejects an invalid email', () => {
+      expect(rules.email().safeParse('not-email').success).toBe(false);
+    });
+  });
+
+  describe('rules.minLength', () => {
+    it('accepts string meeting the minimum', () => {
+      expect(rules.minLength(3).safeParse('abc').success).toBe(true);
+    });
+    it('rejects string below the minimum', () => {
+      expect(rules.minLength(3).safeParse('ab').success).toBe(false);
+    });
+  });
+
+  describe('rules.maxLength', () => {
+    it('accepts string within the maximum', () => {
+      expect(rules.maxLength(5).safeParse('abc').success).toBe(true);
+    });
+    it('rejects string over the maximum', () => {
+      expect(rules.maxLength(5).safeParse('toolong').success).toBe(false);
+    });
+  });
+
+  describe('rules.url', () => {
+    it('accepts a valid URL', () => {
+      expect(rules.url().safeParse('https://example.com').success).toBe(true);
+    });
+    it('rejects an invalid URL', () => {
+      expect(rules.url().safeParse('not-a-url').success).toBe(false);
+    });
+  });
+
+  describe('rules.positiveNumber', () => {
+    it('accepts "42"', () => {
+      expect(rules.positiveNumber().safeParse('42').success).toBe(true);
+    });
+    it('accepts "0.1"', () => {
+      expect(rules.positiveNumber().safeParse('0.1').success).toBe(true);
+    });
+    it('rejects "0"', () => {
+      expect(rules.positiveNumber().safeParse('0').success).toBe(false);
+    });
+    it('rejects negative', () => {
+      expect(rules.positiveNumber().safeParse('-1').success).toBe(false);
+    });
+    it('rejects non-numeric', () => {
+      expect(rules.positiveNumber().safeParse('abc').success).toBe(false);
+    });
+  });
+
+  describe('rules.stellarAddress', () => {
+    // Valid: G + 55 alphanumeric chars = 56 total
+    const valid = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN0';
+    it('accepts a valid address', () => {
+      expect(rules.stellarAddress().safeParse(valid).success).toBe(true);
+    });
+    it('rejects wrong start char', () => {
+      const bad = 'SAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN0';
+      expect(rules.stellarAddress().safeParse(bad).success).toBe(false);
+    });
+    it('rejects too short', () => {
+      expect(rules.stellarAddress().safeParse('GSHORT').success).toBe(false);
+    });
+  });
+
+  describe('rules.stellarSecretKey', () => {
+    // Valid: S + 55 alphanumeric chars = 56 total
+    const valid = 'SAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN0';
+    it('accepts a valid secret key', () => {
+      expect(rules.stellarSecretKey().safeParse(valid).success).toBe(true);
+    });
+    it('rejects wrong start char', () => {
+      const bad = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN0';
+      expect(rules.stellarSecretKey().safeParse(bad).success).toBe(false);
+    });
+  });
+
+  describe('rules.asyncCheck', () => {
+    it('resolves without error when predicate returns true', async () => {
+      const schema = rules.asyncCheck(async () => true, 'Failed');
+      const result = await schema.safeParseAsync('anything');
+      expect(result.success).toBe(true);
+    });
+    it('adds an issue when predicate returns false', async () => {
+      const schema = rules.asyncCheck(async () => false, 'Custom failure');
+      const result = await schema.safeParseAsync('anything');
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe('Custom failure');
+      }
+    });
+  });
+});

--- a/frontend/src/validation/__tests__/schemas.test.tsx
+++ b/frontend/src/validation/__tests__/schemas.test.tsx
@@ -1,0 +1,144 @@
+import {
+  emailSchema,
+  passwordSchema,
+  positiveAmountSchema,
+  stellarAddressSchema,
+  stellarSecretKeySchema,
+  loginSchema,
+  signupSchema,
+  profileSchema,
+  transactionSchema,
+} from '../schemas';
+
+describe('validation/schemas', () => {
+  // ─── emailSchema ───────────────────────────────────────────────────────
+  describe('emailSchema', () => {
+    it('accepts a valid email', () => {
+      expect(emailSchema.safeParse('user@example.com').success).toBe(true);
+    });
+    it('rejects an empty string', () => {
+      expect(emailSchema.safeParse('').success).toBe(false);
+    });
+    it('rejects a malformed email', () => {
+      expect(emailSchema.safeParse('not-an-email').success).toBe(false);
+    });
+  });
+
+  // ─── passwordSchema ────────────────────────────────────────────────────
+  describe('passwordSchema', () => {
+    it('accepts a valid password', () => {
+      expect(passwordSchema.safeParse('Password1').success).toBe(true);
+    });
+    it('rejects a short password', () => {
+      expect(passwordSchema.safeParse('Pass1').success).toBe(false);
+    });
+    it('rejects a password without uppercase', () => {
+      expect(passwordSchema.safeParse('password1').success).toBe(false);
+    });
+    it('rejects a password without digit', () => {
+      expect(passwordSchema.safeParse('Password').success).toBe(false);
+    });
+  });
+
+  // ─── positiveAmountSchema ──────────────────────────────────────────────
+  describe('positiveAmountSchema', () => {
+    it('accepts "100"', () => {
+      expect(positiveAmountSchema.safeParse('100').success).toBe(true);
+    });
+    it('accepts "0.01"', () => {
+      expect(positiveAmountSchema.safeParse('0.01').success).toBe(true);
+    });
+    it('rejects "0"', () => {
+      expect(positiveAmountSchema.safeParse('0').success).toBe(false);
+    });
+    it('rejects negative value', () => {
+      expect(positiveAmountSchema.safeParse('-5').success).toBe(false);
+    });
+    it('rejects non-numeric string', () => {
+      expect(positiveAmountSchema.safeParse('abc').success).toBe(false);
+    });
+  });
+
+  // ─── stellarAddressSchema ──────────────────────────────────────────────
+  // Valid Stellar addresses are 56 chars: G + 55 alphanumeric chars
+  describe('stellarAddressSchema', () => {
+    const valid = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN0'; // 56 chars
+    it('accepts a valid Stellar address', () => {
+      expect(stellarAddressSchema.safeParse(valid).success).toBe(true);
+    });
+    it('rejects an address not starting with G', () => {
+      expect(stellarAddressSchema.safeParse('SAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN0').success).toBe(false);
+    });
+    it('rejects a short address', () => {
+      expect(stellarAddressSchema.safeParse('GSHORT').success).toBe(false);
+    });
+  });
+
+  // ─── stellarSecretKeySchema ────────────────────────────────────────────
+  // Valid Stellar secret keys are 56 chars: S + 55 alphanumeric chars
+  describe('stellarSecretKeySchema', () => {
+    const valid = 'SAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN0'; // 56 chars
+    it('accepts a valid Stellar secret key', () => {
+      expect(stellarSecretKeySchema.safeParse(valid).success).toBe(true);
+    });
+    it('rejects a key not starting with S', () => {
+      expect(stellarSecretKeySchema.safeParse('GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN0').success).toBe(false);
+    });
+  });
+
+  // ─── loginSchema ───────────────────────────────────────────────────────
+  describe('loginSchema', () => {
+    it('accepts valid credentials', () => {
+      expect(loginSchema.safeParse({ email: 'u@example.com', password: 'secret' }).success).toBe(true);
+    });
+    it('rejects empty email', () => {
+      expect(loginSchema.safeParse({ email: '', password: 'secret' }).success).toBe(false);
+    });
+    it('rejects missing password', () => {
+      expect(loginSchema.safeParse({ email: 'u@example.com', password: '' }).success).toBe(false);
+    });
+  });
+
+  // ─── signupSchema ──────────────────────────────────────────────────────
+  describe('signupSchema', () => {
+    const base = { email: 'u@example.com', password: 'Password1', confirmPassword: 'Password1' };
+    it('accepts matching passwords', () => {
+      expect(signupSchema.safeParse(base).success).toBe(true);
+    });
+    it('rejects mismatched passwords', () => {
+      const result = signupSchema.safeParse({ ...base, confirmPassword: 'Different1' });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  // ─── profileSchema ─────────────────────────────────────────────────────
+  describe('profileSchema', () => {
+    it('accepts valid profile', () => {
+      expect(profileSchema.safeParse({ displayName: 'Alice', email: 'a@b.com' }).success).toBe(true);
+    });
+    it('accepts optional bio', () => {
+      expect(profileSchema.safeParse({ displayName: 'Alice', email: 'a@b.com', bio: 'Hi' }).success).toBe(true);
+    });
+    it('rejects empty displayName', () => {
+      expect(profileSchema.safeParse({ displayName: '', email: 'a@b.com' }).success).toBe(false);
+    });
+    it('rejects bio exceeding 200 chars', () => {
+      const long = 'x'.repeat(201);
+      expect(profileSchema.safeParse({ displayName: 'Alice', email: 'a@b.com', bio: long }).success).toBe(false);
+    });
+  });
+
+  // ─── transactionSchema ─────────────────────────────────────────────────
+  describe('transactionSchema', () => {
+    const addr = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN0'; // 56 chars
+    it('accepts a valid transaction', () => {
+      expect(transactionSchema.safeParse({ stellarAddress: addr, amount: '10' }).success).toBe(true);
+    });
+    it('rejects invalid stellar address', () => {
+      expect(transactionSchema.safeParse({ stellarAddress: 'bad', amount: '10' }).success).toBe(false);
+    });
+    it('rejects non-positive amount', () => {
+      expect(transactionSchema.safeParse({ stellarAddress: addr, amount: '0' }).success).toBe(false);
+    });
+  });
+});

--- a/frontend/src/validation/rules.ts
+++ b/frontend/src/validation/rules.ts
@@ -1,0 +1,56 @@
+import { z } from 'zod';
+
+/**
+ * Reusable Zod-based validation rules that can be composed into schemas.
+ * Each factory returns a ZodTypeAny so they work both standalone and with
+ * `zodResolver` from @hookform/resolvers/zod.
+ */
+
+// ─── Primitive rules ──────────────────────────────────────────────────────────
+
+export const rules = {
+  required: (msg = 'This field is required') => z.string().trim().min(1, msg),
+
+  email: (msg = 'Please enter a valid email address') =>
+    z.string().trim().min(1, 'Email is required').email(msg),
+
+  minLength: (min: number, msg?: string) =>
+    z.string().min(min, msg ?? `Must be at least ${min} characters`),
+
+  maxLength: (max: number, msg?: string) =>
+    z.string().max(max, msg ?? `Must be no more than ${max} characters`),
+
+  pattern: (regex: RegExp, msg: string) =>
+    z.string().regex(regex, msg),
+
+  url: (msg = 'Please enter a valid URL') =>
+    z.string().url(msg),
+
+  positiveNumber: (msg = 'Must be a positive number') =>
+    z.string().refine((v) => !isNaN(Number(v)) && Number(v) > 0, msg),
+
+  /** Stellar public key: starts with 'G', 56 chars total */
+  stellarAddress: (msg = 'Please enter a valid Stellar address') =>
+    z.string().regex(/^G[A-Z0-9]{55}$/, msg),
+
+  /** Stellar secret key: starts with 'S', 56 chars total */
+  stellarSecretKey: (msg = 'Please enter a valid Stellar secret key') =>
+    z.string().regex(/^S[A-Z0-9]{55}$/, msg),
+
+  /**
+   * Async rule — wraps an async predicate so the error message is clear.
+   * Usage: `rules.asyncCheck(checkAddressExists, 'Address does not exist')`
+   */
+  asyncCheck: <T>(
+    fn: (value: T) => Promise<boolean>,
+    msg: string,
+  ) =>
+    z.any().superRefine(async (val: T, ctx) => {
+      const ok = await fn(val);
+      if (!ok) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: msg });
+      }
+    }),
+};
+
+export type Rules = typeof rules;

--- a/frontend/src/validation/schemas.ts
+++ b/frontend/src/validation/schemas.ts
@@ -1,0 +1,73 @@
+import { z } from 'zod';
+
+// ─── Primitives ──────────────────────────────────────────────────────────────
+
+/** Non-empty trimmed string */
+const requiredString = (msg = 'This field is required') =>
+  z.string().trim().min(1, msg);
+
+// ─── Blockchain ───────────────────────────────────────────────────────────────
+
+export const stellarAddressSchema = z
+  .string()
+  .regex(/^G[A-Z0-9]{55}$/, 'Please enter a valid Stellar address (starts with G, 56 chars)');
+
+export const stellarSecretKeySchema = z
+  .string()
+  .regex(/^S[A-Z0-9]{55}$/, 'Please enter a valid Stellar secret key (starts with S, 56 chars)');
+
+// ─── Common field schemas ─────────────────────────────────────────────────────
+
+export const emailSchema = z
+  .string()
+  .trim()
+  .min(1, 'Email is required')
+  .email('Please enter a valid email address');
+
+export const passwordSchema = z
+  .string()
+  .min(8, 'Password must be at least 8 characters')
+  .regex(/[A-Z]/, 'Password must contain at least one uppercase letter')
+  .regex(/[0-9]/, 'Password must contain at least one number');
+
+export const positiveAmountSchema = z
+  .string()
+  .min(1, 'Amount is required')
+  .refine((v) => !isNaN(Number(v)) && Number(v) > 0, 'Amount must be a positive number');
+
+// ─── Composite form schemas ───────────────────────────────────────────────────
+
+export const loginSchema = z.object({
+  email: emailSchema,
+  password: requiredString('Password is required'),
+});
+
+export const signupSchema = z
+  .object({
+    email: emailSchema,
+    password: passwordSchema,
+    confirmPassword: requiredString('Please confirm your password'),
+  })
+  .refine((d) => d.password === d.confirmPassword, {
+    message: 'Passwords do not match',
+    path: ['confirmPassword'],
+  });
+
+export const profileSchema = z.object({
+  displayName: requiredString('Display name is required').max(50, 'Max 50 characters'),
+  email: emailSchema,
+  bio: z.string().max(200, 'Bio must be 200 characters or less').optional(),
+});
+
+export const transactionSchema = z.object({
+  stellarAddress: stellarAddressSchema,
+  amount: positiveAmountSchema,
+  memo: z.string().max(100, 'Memo must be 100 characters or less').optional(),
+});
+
+// ─── Inferred types ───────────────────────────────────────────────────────────
+
+export type LoginFormValues = z.infer<typeof loginSchema>;
+export type SignupFormValues = z.infer<typeof signupSchema>;
+export type ProfileFormValues = z.infer<typeof profileSchema>;
+export type TransactionFormValues = z.infer<typeof transactionSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -352,6 +352,9 @@ importers:
       '@emotion/styled':
         specifier: ^11.11.0
         version: 11.14.1(@emotion/react@11.14.0(@types/react@18.3.31)(react@18.3.1))(@types/react@18.3.31)(react@18.3.1)
+      '@hookform/resolvers':
+        specifier: 3.10.0
+        version: 3.10.0(react-hook-form@7.54.2(react@18.3.1))
       '@mui/icons-material':
         specifier: ^5.15.0
         version: 5.15.0(@mui/material@5.18.0(@emotion/react@11.14.0(@types/react@18.3.31)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.31)(react@18.3.1))(@types/react@18.3.31)(react@18.3.1))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(react@18.3.1)
@@ -376,6 +379,9 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.3.1(react@18.3.1)
+      react-hook-form:
+        specifier: 7.54.2
+        version: 7.54.2(react@18.3.1)
       react-i18next:
         specifier: ^13.5.0
         version: 13.5.0(i18next@23.16.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.86.0(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)
@@ -385,6 +391,9 @@ importers:
       recharts:
         specifier: ^3.2.1
         version: 3.8.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-is@19.2.7)(react@18.3.1)(redux@5.0.1)
+      zod:
+        specifier: 3.24.2
+        version: 3.24.2
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^5.16.0
@@ -1549,6 +1558,11 @@ packages:
   '@gulpjs/to-absolute-glob@4.0.0':
     resolution: {integrity: sha512-kjotm7XJrJ6v+7knhPaRgaT6q8F8K2jiafwYdNHLzmV0uGLuZY43FK6smNSHUPrhq5kX2slCUy+RGG/xGqmIKA==}
     engines: {node: '>=10.13.0'}
+
+  '@hookform/resolvers@3.10.0':
+    resolution: {integrity: sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==}
+    peerDependencies:
+      react-hook-form: ^7.0.0
 
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
@@ -3059,9 +3073,11 @@ packages:
 
   '@stellar/stellar-base@11.0.1':
     resolution: {integrity: sha512-VQh+1KEtFjegD6spx08+lENt8tQOkQQQZoLtqExjpRXyWlqDhEe+bXMlBTYKDc5MIynHyD42RPEib27UG17trA==}
+    deprecated: This package is now rolled into @stellar/stellar-sdk. Please use @stellar/stellar-sdk to continue receiving updates and support.
 
   '@stellar/stellar-base@12.1.1':
     resolution: {integrity: sha512-gOBSOFDepihslcInlqnxKZdIW9dMUO1tpOm3AtJR33K2OvpXG6SaVHCzAmCFArcCqI9zXTEiSoh70T48TmiHJA==}
+    deprecated: This package is now rolled into @stellar/stellar-sdk. Please use @stellar/stellar-sdk to continue receiving updates and support.
 
   '@stellar/stellar-sdk@11.3.0':
     resolution: {integrity: sha512-i+heopibJNRA7iM8rEPz0AXphBPYvy2HDo8rxbDwWpozwCfw8kglP9cLkkhgJe8YicgLrdExz/iQZaLpqLC+6w==}
@@ -8287,6 +8303,12 @@ packages:
   react-error-overlay@6.1.0:
     resolution: {integrity: sha512-SN/U6Ytxf1QGkw/9ve5Y+NxBbZM6Ht95tuXNMKs8EJyFa/Vy/+Co3stop3KBHARfn/giv+Lj1uUnTfOJ3moFEQ==}
 
+  react-hook-form@7.54.2:
+    resolution: {integrity: sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+
   react-i18next@13.5.0:
     resolution: {integrity: sha512-CFJ5NDGJ2MUyBohEHxljOq/39NQ972rh1ajnadG9BjTk+UXbHLq4z5DKEbEQBDoIhUmmbuS/fIMJKo6VOax1HA==}
     peerDependencies:
@@ -10021,6 +10043,9 @@ packages:
   zdog@1.1.3:
     resolution: {integrity: sha512-raRj6r0gPzopFm5XWBJZr/NuV4EEnT4iE+U3dp5FV5pCb588Gmm3zLIp/j9yqqcMiHH8VNQlerLTgOqL7krh6w==}
 
+  zod@3.24.2:
+    resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
+
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
@@ -11224,6 +11249,10 @@ snapshots:
   '@gulpjs/to-absolute-glob@4.0.0':
     dependencies:
       is-negated-glob: 1.0.0
+
+  '@hookform/resolvers@3.10.0(react-hook-form@7.54.2(react@18.3.1))':
+    dependencies:
+      react-hook-form: 7.54.2(react@18.3.1)
 
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
@@ -19837,6 +19866,10 @@ snapshots:
 
   react-error-overlay@6.1.0: {}
 
+  react-hook-form@7.54.2(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+
   react-i18next@13.5.0(i18next@23.16.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.86.0(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.29.7
@@ -21956,6 +21989,8 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zdog@1.1.3: {}
+
+  zod@3.24.2: {}
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
- Install react-hook-form@7.54.2, zod@3.24.2, @hookform/resolvers@3.10.0
- Create frontend/src/validation/schemas.ts with Zod schemas for login, signup, profile, and transaction forms, plus Stellar address/key schemas
- Create frontend/src/validation/rules.ts with composable Zod-based rules including async validation support
- Create frontend/src/components/forms/ subdir with:
  - FormField.tsx: generic RHF useController-powered field (text, email, password, number, textarea, select) with real-time validation, aria-invalid, aria-describedby, accessible labels and error linking
  - FormError.tsx: accessible inline error with role=alert, aria-live
  - FormSubmit.tsx: submit button disabled while invalid/submitting, optional reset button, aria-busy/aria-disabled
  - index.ts: clean barrel export
- Add comprehensive tests (138 passing, 10 suites):
  - forms/__tests__/FormError.test.tsx
  - forms/__tests__/FormField.test.tsx
  - forms/__tests__/FormSubmit.test.tsx
  - validation/__tests__/schemas.test.tsx
  - validation/__tests__/rules.test.tsx
- Export new components from components/index.ts

Closes #157

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive form handling system with validation for user inputs (authentication, profiles, transactions).
  * Introduced error messages and real-time validation feedback for form fields.
  * Enhanced form components supporting text inputs, text areas, dropdowns, and submit buttons with accessibility features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->