### PR TITLE
feat: add state persistence layer with storage utils, context, and hook

### DIFF
--- a/frontend/src/contexts/PersistenceContext.tsx
+++ b/frontend/src/contexts/PersistenceContext.tsx
@@ -9,8 +9,6 @@ import {
   loadPreferences,
   savePreferences,
   clearPreferences,
-  addRecentSearch,
-  clearRecentSearches,
   type UserPreferences,
 } from '../utils/persistence';
 import { storageClear } from '../utils/storage';
@@ -44,13 +42,21 @@ export const PersistenceProvider: React.FC<{ children: React.ReactNode }> = ({ c
   }, []);
 
   const handleAddRecentSearch = useCallback((term: string) => {
-    addRecentSearch(term);
-    setPreferences(loadPreferences());
+    setPreferences((prev) => {
+      const searches = prev.recentSearches ?? [];
+      const filtered = searches.filter((s) => s !== term);
+      const updated = { ...prev, recentSearches: [term, ...filtered].slice(0, 10) };
+      savePreferences(updated);
+      return updated;
+    });
   }, []);
 
   const handleClearRecentSearches = useCallback(() => {
-    clearRecentSearches();
-    setPreferences(loadPreferences());
+    setPreferences((prev) => {
+      const updated = { ...prev, recentSearches: [] };
+      savePreferences(updated);
+      return updated;
+    });
   }, []);
 
   const contextValue = useMemo(

--- a/frontend/src/contexts/PersistenceContext.tsx
+++ b/frontend/src/contexts/PersistenceContext.tsx
@@ -1,0 +1,80 @@
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useMemo,
+} from 'react';
+import {
+  loadPreferences,
+  savePreferences,
+  clearPreferences,
+  addRecentSearch,
+  clearRecentSearches,
+  type UserPreferences,
+} from '../utils/persistence';
+import { storageClear } from '../utils/storage';
+
+interface PersistenceContextType {
+  preferences: UserPreferences;
+  updatePreferences: (partial: Partial<UserPreferences>) => void;
+  clearAllData: () => void;
+  addRecentSearch: (term: string) => void;
+  clearRecentSearches: () => void;
+}
+
+const PersistenceContext = createContext<PersistenceContextType | undefined>(undefined);
+
+export const PersistenceProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [preferences, setPreferences] = useState<UserPreferences>(loadPreferences);
+
+  const updatePreferences = useCallback((partial: Partial<UserPreferences>) => {
+    setPreferences((prev) => {
+      const updated = { ...prev, ...partial };
+      savePreferences(updated);
+      return updated;
+    });
+  }, []);
+
+  const clearAllData = useCallback(() => {
+    clearPreferences();
+    storageClear('local');
+    storageClear('session');
+    setPreferences({});
+  }, []);
+
+  const handleAddRecentSearch = useCallback((term: string) => {
+    addRecentSearch(term);
+    setPreferences(loadPreferences());
+  }, []);
+
+  const handleClearRecentSearches = useCallback(() => {
+    clearRecentSearches();
+    setPreferences(loadPreferences());
+  }, []);
+
+  const contextValue = useMemo(
+    () => ({
+      preferences,
+      updatePreferences,
+      clearAllData,
+      addRecentSearch: handleAddRecentSearch,
+      clearRecentSearches: handleClearRecentSearches,
+    }),
+    [preferences, updatePreferences, clearAllData, handleAddRecentSearch, handleClearRecentSearches]
+  );
+
+  return (
+    <PersistenceContext.Provider value={contextValue}>
+      {children}
+    </PersistenceContext.Provider>
+  );
+};
+
+export const usePersistenceContext = (): PersistenceContextType => {
+  const context = useContext(PersistenceContext);
+  if (!context) {
+    throw new Error('usePersistenceContext must be used within a PersistenceProvider');
+  }
+  return context;
+};

--- a/frontend/src/hooks/usePersistence.ts
+++ b/frontend/src/hooks/usePersistence.ts
@@ -1,0 +1,10 @@
+// ─── usePersistence ───────────────────────────────────────────────────────────
+// Convenience hook for accessing persistence state and actions.
+
+import { usePersistenceContext } from '../contexts/PersistenceContext';
+
+const usePersistence = () => {
+  return usePersistenceContext();
+};
+
+export default usePersistence;

--- a/frontend/src/utils/persistence.ts
+++ b/frontend/src/utils/persistence.ts
@@ -14,7 +14,22 @@ export interface UserPreferences {
 const PREFERENCES_KEY = 'chenaikit_preferences';
 
 export const loadPreferences = (): UserPreferences => {
-  return storageGet<UserPreferences>(PREFERENCES_KEY) ?? {};
+  const raw = storageGet<unknown>(PREFERENCES_KEY);
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
+  const data = raw as Record<string, unknown>;
+  return {
+    language: typeof data.language === 'string' ? data.language : undefined,
+    dashboardLayout: typeof data.dashboardLayout === 'string' ? data.dashboardLayout : undefined,
+    recentSearches: Array.isArray(data.recentSearches)
+      ? (data.recentSearches as unknown[]).filter((s): s is string => typeof s === 'string')
+      : [],
+    filterStates: typeof data.filterStates === 'object' && !Array.isArray(data.filterStates) && data.filterStates !== null
+      ? (data.filterStates as Record<string, unknown>)
+      : undefined,
+    columnLayouts: typeof data.columnLayouts === 'object' && !Array.isArray(data.columnLayouts) && data.columnLayouts !== null
+      ? (data.columnLayouts as Record<string, unknown>)
+      : undefined,
+  };
 };
 
 export const savePreferences = (prefs: UserPreferences): boolean => {

--- a/frontend/src/utils/persistence.ts
+++ b/frontend/src/utils/persistence.ts
@@ -1,0 +1,47 @@
+// ─── Persistence helpers ──────────────────────────────────────────────────────
+// Higher-level helpers built on top of storage.ts.
+
+import { storageGet, storageSet, storageRemove } from './storage';
+
+export interface UserPreferences {
+  language?: string;
+  dashboardLayout?: string;
+  recentSearches?: string[];
+  filterStates?: Record<string, unknown>;
+  columnLayouts?: Record<string, unknown>;
+}
+
+const PREFERENCES_KEY = 'chenaikit_preferences';
+
+export const loadPreferences = (): UserPreferences => {
+  return storageGet<UserPreferences>(PREFERENCES_KEY) ?? {};
+};
+
+export const savePreferences = (prefs: UserPreferences): boolean => {
+  return storageSet(PREFERENCES_KEY, prefs);
+};
+
+export const updatePreferences = (partial: Partial<UserPreferences>): boolean => {
+  const current = loadPreferences();
+  return savePreferences({ ...current, ...partial });
+};
+
+export const clearPreferences = (): boolean => {
+  return storageRemove(PREFERENCES_KEY);
+};
+
+// ─── Recent searches ──────────────────────────────────────────────────────────
+
+const MAX_RECENT_SEARCHES = 10;
+
+export const addRecentSearch = (term: string): boolean => {
+  const prefs = loadPreferences();
+  const searches = prefs.recentSearches ?? [];
+  const filtered = searches.filter((s) => s !== term);
+  const updated = [term, ...filtered].slice(0, MAX_RECENT_SEARCHES);
+  return updatePreferences({ recentSearches: updated });
+};
+
+export const clearRecentSearches = (): boolean => {
+  return updatePreferences({ recentSearches: [] });
+};

--- a/frontend/src/utils/storage.ts
+++ b/frontend/src/utils/storage.ts
@@ -1,0 +1,57 @@
+// ─── Storage utility ─────────────────────────────────────────────────────────
+// Thin wrappers around localStorage and sessionStorage with safe fallbacks.
+
+export type StorageType = 'local' | 'session';
+
+const getStorage = (type: StorageType): Storage | null => {
+  try {
+    return type === 'local' ? window.localStorage : window.sessionStorage;
+  } catch {
+    return null;
+  }
+};
+
+export const storageGet = <T>(key: string, type: StorageType = 'local'): T | null => {
+  try {
+    const storage = getStorage(type);
+    if (!storage) return null;
+    const item = storage.getItem(key);
+    if (item === null) return null;
+    return JSON.parse(item) as T;
+  } catch {
+    return null;
+  }
+};
+
+export const storageSet = <T>(key: string, value: T, type: StorageType = 'local'): boolean => {
+  try {
+    const storage = getStorage(type);
+    if (!storage) return false;
+    storage.setItem(key, JSON.stringify(value));
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export const storageRemove = (key: string, type: StorageType = 'local'): boolean => {
+  try {
+    const storage = getStorage(type);
+    if (!storage) return false;
+    storage.removeItem(key);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export const storageClear = (type: StorageType = 'local'): boolean => {
+  try {
+    const storage = getStorage(type);
+    if (!storage) return false;
+    storage.clear();
+    return true;
+  } catch {
+    return false;
+  }
+};


### PR DESCRIPTION
Implements a lightweight state persistence layer so user preferences and application state survive page refreshes.
feat: add state persistence layer with storage utils, context, and hook

## What's Added

**`frontend/src/utils/storage.ts`**
- Safe wrappers around localStorage and sessionStorage with try/catch fallbacks
- `storageGet`, `storageSet`, `storageRemove`, `storageClear` — typed generics

**`frontend/src/utils/persistence.ts`**
- Higher-level helpers built on storage.ts
- `UserPreferences` interface covering language, dashboard layout, filter states, column layouts, recent searches
- `loadPreferences` with payload validation and coercion
- `savePreferences`, `updatePreferences`, `clearPreferences`
- Recent search management with 10-item cap

**`frontend/src/contexts/PersistenceContext.tsx`**
- React context following existing ThemeContext conventions
- `PersistenceProvider` wraps the app and exposes preferences state
- Unified functional updaters to prevent state/storage drift
- `clearAllData` clears both localStorage and sessionStorage on logout

**`frontend/src/hooks/usePersistence.ts`**
- Convenience hook following existing hook patterns

## CI Results
- Lint: 0 errors
- Build: compiled successfully
- Tests: 326 passed, 0 failed

Closes #166