### PR TITLE
feat(frontend): fix #167 by adding keyboard shortcuts

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "react-dom": "^18.2.0",
     "react-dropzone": "^15.0.0",
     "react-hook-form": "7.54.2",
+    "react-hotkeys-hook": "^5.3.2",
     "react-i18next": "^13.5.0",
     "react-router-dom": "^6.8.0",
     "recharts": "^3.2.1",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,18 +1,22 @@
 import React, { useState, Suspense, lazy } from 'react';
-import { BrowserRouter, Routes, Route, Navigate, Link } from 'react-router-dom';
-import { Box, Button, Typography } from '@mui/material';
+import { BrowserRouter, Routes, Route, Navigate, Link, useNavigate } from 'react-router-dom';
+import { Box, Button, Tooltip, Typography } from '@mui/material';
 import { Logout as LogoutIcon, AccountCircle } from '@mui/icons-material';
 import FormValidationExample from './components/FormValidationExample';
 import DataVisualizationExample from './components/DataVisualizationExample';
 import { AnalyticsDashboard } from './components';
 import { AuthProvider, useAuth } from './components/auth/AuthContext';
 import ProtectedRoute from './components/auth/ProtectedRoute';
-import { ThemeProvider } from './contexts/ThemeContext';
-import { ToastProvider } from './contexts/ToastContext';
+import { ThemeProvider, useThemeMode } from './contexts/ThemeContext';
+import { ToastProvider, useToastContext } from './contexts/ToastContext';
 import { LoadingProvider } from './contexts/LoadingContext';
+import { ShortcutProvider, useShortcutContext } from './contexts/ShortcutContext';
 import { LoadingSpinner } from './components/LoadingSpinner';
 import ToastContainer from './components/ToastContainer';
 import ThemeToggle from './components/ThemeToggle';
+import ShortcutHelp, { ShortcutFeedback } from './components/ShortcutHelp';
+import { useKeyboardShortcut, useShortcutLabel } from './hooks/useKeyboardShortcuts';
+import { getDefaultShortcut } from './shortcuts';
 import './components/FormValidation.css';
 
 const Login = lazy(() => import('./pages/Login'));
@@ -59,26 +63,80 @@ const PrivacyPage: React.FC = () => {
   );
 };
 
+const getShortcut = (id: Parameters<typeof getDefaultShortcut>[0]) => {
+  const shortcut = getDefaultShortcut(id);
+  if (!shortcut) {
+    throw new Error(`Missing shortcut definition: ${id}`);
+  }
+  return shortcut;
+};
+
+const AppShortcutController: React.FC = () => {
+  const navigate = useNavigate();
+  const { openHelp } = useShortcutContext();
+  const { toggleTheme } = useThemeMode();
+  const { user, logout } = useAuth();
+  const toast = useToastContext();
+
+  useKeyboardShortcut(getShortcut('help.open'), () => openHelp());
+  useKeyboardShortcut(getShortcut('settings.shortcuts'), () => openHelp());
+  useKeyboardShortcut(getShortcut('navigation.dashboard'), () => navigate('/'));
+  useKeyboardShortcut(getShortcut('navigation.profile'), () => navigate('/profile'));
+  useKeyboardShortcut(getShortcut('navigation.settings'), () => navigate('/settings'));
+  useKeyboardShortcut(getShortcut('action.theme.toggle'), () => toggleTheme());
+  useKeyboardShortcut(
+    getShortcut('action.signout'),
+    () => {
+      if (user) logout();
+    },
+    { enabled: Boolean(user) }
+  );
+  useKeyboardShortcut(getShortcut('search.focus'), () => {
+    const searchTarget = document.querySelector<HTMLElement>(
+      '[data-shortcut-search="true"], input[type="search"], input[aria-label*="search" i], input[placeholder*="search" i]'
+    );
+
+    if (searchTarget) {
+      searchTarget.focus();
+      return;
+    }
+
+    toast.info('No search field is available on this view.', { duration: 1800 });
+  });
+
+  return null;
+};
+
 const DashboardShell: React.FC = () => {
   const [activeDemo, setActiveDemo] = useState<'analytics' | 'forms' | 'visualization'>('analytics');
   const { user, logout } = useAuth();
+  const analyticsShortcut = useShortcutLabel('dashboard.analytics');
+  const formsShortcut = useShortcutLabel('dashboard.forms');
+  const visualizationShortcut = useShortcutLabel('dashboard.visualization');
+  const profileShortcut = useShortcutLabel('navigation.profile');
+  const settingsShortcut = useShortcutLabel('navigation.settings');
+  const signoutShortcut = useShortcutLabel('action.signout');
+
+  useKeyboardShortcut(getShortcut('dashboard.analytics'), () => setActiveDemo('analytics'));
+  useKeyboardShortcut(getShortcut('dashboard.forms'), () => setActiveDemo('forms'));
+  useKeyboardShortcut(getShortcut('dashboard.visualization'), () => setActiveDemo('visualization'));
 
   return (
     <div className="App">
-      <header style={{ 
-        background: 'linear-gradient(135deg, #0f172a 0%, #334155 100%)', 
-        color: 'white', 
-        padding: '30px 20px', 
+      <header style={{
+        background: 'linear-gradient(135deg, #0f172a 0%, #334155 100%)',
+        color: 'white',
+        padding: '30px 20px',
         textAlign: 'center',
         position: 'relative'
       }}>
         {user && (
-          <Box sx={{ 
-            position: { xs: 'relative', sm: 'absolute' }, 
-            top: 20, 
-            right: 20, 
-            display: 'flex', 
-            alignItems: 'center', 
+          <Box sx={{
+            position: { xs: 'relative', sm: 'absolute' },
+            top: 20,
+            right: 20,
+            display: 'flex',
+            alignItems: 'center',
             gap: 1,
             justifyContent: 'center',
             mb: { xs: 2, sm: 0 }
@@ -88,24 +146,27 @@ const DashboardShell: React.FC = () => {
             <Typography variant="body2" sx={{ fontWeight: 500, color: '#e2e8f0' }}>
               {user.email}
             </Typography>
-            <Button
-              variant="outlined"
-              size="small"
-              onClick={logout}
-              startIcon={<LogoutIcon />}
-              sx={{
-                color: 'white',
-                borderColor: 'rgba(255, 255, 255, 0.3)',
-                textTransform: 'none',
-                borderRadius: '8px',
-                '&:hover': {
-                  borderColor: 'white',
-                  backgroundColor: 'rgba(255, 255, 255, 0.1)',
-                }
-              }}
-            >
-              Sign Out
-            </Button>
+            <Tooltip title={`Sign out (${signoutShortcut})`}>
+              <Button
+                aria-keyshortcuts={signoutShortcut}
+                variant="outlined"
+                size="small"
+                onClick={logout}
+                startIcon={<LogoutIcon />}
+                sx={{
+                  color: 'white',
+                  borderColor: 'rgba(255, 255, 255, 0.3)',
+                  textTransform: 'none',
+                  borderRadius: '8px',
+                  '&:hover': {
+                    borderColor: 'white',
+                    backgroundColor: 'rgba(255, 255, 255, 0.1)',
+                  }
+                }}
+              >
+                Sign Out
+              </Button>
+            </Tooltip>
           </Box>
         )}
 
@@ -115,10 +176,12 @@ const DashboardShell: React.FC = () => {
         <p style={{ fontSize: '18px', opacity: 0.9, marginBottom: '30px' }}>
           Advanced AI Insights & Blockchain Monitoring
         </p>
-        
+
         <div style={{ display: 'flex', gap: '12px', justifyContent: 'center', flexWrap: 'wrap' }}>
           <button
             onClick={() => setActiveDemo('analytics')}
+            aria-keyshortcuts={analyticsShortcut}
+            title={`Analytics dashboard (${analyticsShortcut})`}
             style={{
               padding: '12px 24px',
               background: activeDemo === 'analytics' ? 'rgba(255, 255, 255, 0.2)' : 'transparent',
@@ -131,10 +194,12 @@ const DashboardShell: React.FC = () => {
               transition: 'all 0.3s ease'
             }}
           >
-            📈 Analytics Dashboard
+            📈 Analytics Dashboard ({analyticsShortcut})
           </button>
           <button
             onClick={() => setActiveDemo('forms')}
+            aria-keyshortcuts={formsShortcut}
+            title={`Forms (${formsShortcut})`}
             style={{
               padding: '12px 24px',
               background: activeDemo === 'forms' ? 'rgba(255, 255, 255, 0.2)' : 'transparent',
@@ -147,10 +212,12 @@ const DashboardShell: React.FC = () => {
               transition: 'all 0.3s ease'
             }}
           >
-            📝 Forms
+            📝 Forms ({formsShortcut})
           </button>
           <button
             onClick={() => setActiveDemo('visualization')}
+            aria-keyshortcuts={visualizationShortcut}
+            title={`Sandbox (${visualizationShortcut})`}
             style={{
               padding: '12px 24px',
               background: activeDemo === 'visualization' ? 'rgba(255, 255, 255, 0.2)' : 'transparent',
@@ -163,9 +230,9 @@ const DashboardShell: React.FC = () => {
               transition: 'all 0.3s ease'
             }}
           >
-            📊 Sandbox
+            📊 Sandbox ({visualizationShortcut})
           </button>
-          <Link to="/profile" style={{
+          <Link to="/profile" aria-keyshortcuts={profileShortcut} title={`Profile (${profileShortcut})`} style={{
               padding: '12px 24px',
               background: 'transparent',
               color: 'white',
@@ -180,9 +247,9 @@ const DashboardShell: React.FC = () => {
               alignItems: 'center',
               gap: '8px'
             }}>
-            👤 Profile
+            👤 Profile ({profileShortcut})
           </Link>
-          <Link to="/settings" style={{
+          <Link to="/settings" aria-keyshortcuts={settingsShortcut} title={`Settings (${settingsShortcut})`} style={{
               padding: '12px 24px',
               background: 'transparent',
               color: 'white',
@@ -197,11 +264,11 @@ const DashboardShell: React.FC = () => {
               alignItems: 'center',
               gap: '8px'
             }}>
-            ⚙️ Settings
+            ⚙️ Settings ({settingsShortcut})
           </Link>
         </div>
       </header>
-      
+
       <main style={{ minHeight: 'calc(100vh - 200px)' }}>
         <Suspense fallback={<LoadingSpinner fullScreen />}>
           {activeDemo === 'analytics' && <AnalyticsDashboard />}
@@ -209,7 +276,7 @@ const DashboardShell: React.FC = () => {
           {activeDemo === 'visualization' && <DataVisualizationExample />}
         </Suspense>
       </main>
-      
+
       <Box
         component="footer"
         sx={{
@@ -234,130 +301,134 @@ const App: React.FC = () => {
       <LoadingProvider>
       <ToastProvider>
         <AuthProvider>
-
         <BrowserRouter>
-        <Routes>
-          <Route path="/login" element={<Login />} />
-          <Route path="/signup" element={<Signup />} />
-          <Route path="/forgot-password" element={<ForgotPasswordPage />} />
-          <Route path="/terms" element={<TermsPage />} />
-          <Route path="/privacy" element={<PrivacyPage />} />
-          <Route 
-            path="/" 
-            element={
-              <ProtectedRoute>
-                <DashboardShell />
-              </ProtectedRoute>
-            } 
-          />
-          <Route 
-            path="/profile" 
-            element={
-              <ProtectedRoute>
-                <Profile 
-                  user={{
-                    id: 1,
-                    email: 'user@example.com',
-                    name: 'Demo User',
-                    role: 'user'
-                  }}
-                  stats={{
-                    transactions: 156,
-                    score: 720,
-                    activeDays: 45
-                  }}
-                  activity={[]}
-                  onUpdateProfile={async () => {
-                    // TODO: Integrate with backend API
-                  }}
-                />
-              </ProtectedRoute>
-            } 
-          />
-          <Route 
-            path="/settings" 
-            element={
-              <ProtectedRoute>
-                <Settings 
-                  user={{
-                    id: 1,
-                    email: 'user@example.com',
-                    name: 'Demo User',
-                    role: 'user',
-                    language: 'en',
-                    theme: 'light'
-                  }}
-                  notificationPreferences={{
-                    emailNotifications: true,
-                    pushNotifications: true,
-                    transactionAlerts: true,
-                    scoreChanges: true,
-                    marketingEmails: false,
-                    securityAlerts: true,
-                    weeklyReport: false,
-                    priceAlerts: true
-                  }}
-                  securitySettings={{
-                    twoFactorEnabled: false,
-                    sessions: [
-                      {
-                        id: '1',
-                        device: 'Chrome on macOS',
-                        location: 'San Francisco, CA',
-                        lastActive: 'Just now',
-                        current: true
-                      }
-                    ],
-                    loginHistory: [
-                      {
-                        id: '1',
-                        date: '2024-01-15 10:30 AM',
-                        device: 'Chrome on macOS',
-                        location: 'San Francisco, CA',
-                        status: 'success'
-                      }
-                    ]
-                  }}
-                  apiKeys={[]}
-                  onUpdateAccount={async () => {
-                    // TODO: Integrate with backend API
-                  }}
-                  onDeleteAccount={async () => {
-                    // TODO: Integrate with backend API
-                  }}
-                  onUpdateNotificationPreferences={async () => {
-                    // TODO: Integrate with backend API
-                  }}
-                  onChangePassword={async () => {
-                    // TODO: Integrate with backend API
-                  }}
-                  onEnableTwoFactor={async () => {
-                    // TODO: Integrate with backend API
-                  }}
-                  onDisableTwoFactor={async () => {
-                    // TODO: Integrate with backend API
-                  }}
-                  onRevokeSession={async () => {
-                    // TODO: Integrate with backend API
-                  }}
-                  onRevokeAllSessions={async () => {
-                    // TODO: Integrate with backend API
-                  }}
-                  onCreateApiKey={async () => {
-                    return { key: 'ck_' + Math.random().toString(36).substring(2) };
-                  }}
-                  onDeleteApiKey={async () => {
-                    // TODO: Integrate with backend API
-                  }}
-                  onRegenerateApiKey={async () => {
-                    return { key: 'ck_' + Math.random().toString(36).substring(2) };
-                  }}
-                />
-              </ProtectedRoute>
-            } 
-          />
-          <Route path="*" element={<Navigate to="/" replace />} />
-        </Routes>
+        <ShortcutProvider>
+          <AppShortcutController />
+          <Routes>
+            <Route path="/login" element={<Login />} />
+            <Route path="/signup" element={<Signup />} />
+            <Route path="/forgot-password" element={<ForgotPasswordPage />} />
+            <Route path="/terms" element={<TermsPage />} />
+            <Route path="/privacy" element={<PrivacyPage />} />
+            <Route
+              path="/"
+              element={
+                <ProtectedRoute>
+                  <DashboardShell />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/profile"
+              element={
+                <ProtectedRoute>
+                  <Profile
+                    user={{
+                      id: 1,
+                      email: 'user@example.com',
+                      name: 'Demo User',
+                      role: 'user'
+                    }}
+                    stats={{
+                      transactions: 156,
+                      score: 720,
+                      activeDays: 45
+                    }}
+                    activity={[]}
+                    onUpdateProfile={async () => {
+                      // TODO: Integrate with backend API
+                    }}
+                  />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/settings"
+              element={
+                <ProtectedRoute>
+                  <Settings
+                    user={{
+                      id: 1,
+                      email: 'user@example.com',
+                      name: 'Demo User',
+                      role: 'user',
+                      language: 'en',
+                      theme: 'light'
+                    }}
+                    notificationPreferences={{
+                      emailNotifications: true,
+                      pushNotifications: true,
+                      transactionAlerts: true,
+                      scoreChanges: true,
+                      marketingEmails: false,
+                      securityAlerts: true,
+                      weeklyReport: false,
+                      priceAlerts: true
+                    }}
+                    securitySettings={{
+                      twoFactorEnabled: false,
+                      sessions: [
+                        {
+                          id: '1',
+                          device: 'Chrome on macOS',
+                          location: 'San Francisco, CA',
+                          lastActive: 'Just now',
+                          current: true
+                        }
+                      ],
+                      loginHistory: [
+                        {
+                          id: '1',
+                          date: '2024-01-15 10:30 AM',
+                          device: 'Chrome on macOS',
+                          location: 'San Francisco, CA',
+                          status: 'success'
+                        }
+                      ]
+                    }}
+                    apiKeys={[]}
+                    onUpdateAccount={async () => {
+                      // TODO: Integrate with backend API
+                    }}
+                    onDeleteAccount={async () => {
+                      // TODO: Integrate with backend API
+                    }}
+                    onUpdateNotificationPreferences={async () => {
+                      // TODO: Integrate with backend API
+                    }}
+                    onChangePassword={async () => {
+                      // TODO: Integrate with backend API
+                    }}
+                    onEnableTwoFactor={async () => {
+                      // TODO: Integrate with backend API
+                    }}
+                    onDisableTwoFactor={async () => {
+                      // TODO: Integrate with backend API
+                    }}
+                    onRevokeSession={async () => {
+                      // TODO: Integrate with backend API
+                    }}
+                    onRevokeAllSessions={async () => {
+                      // TODO: Integrate with backend API
+                    }}
+                    onCreateApiKey={async () => {
+                      return { key: 'ck_' + Math.random().toString(36).substring(2) };
+                    }}
+                    onDeleteApiKey={async () => {
+                      // TODO: Integrate with backend API
+                    }}
+                    onRegenerateApiKey={async () => {
+                      return { key: 'ck_' + Math.random().toString(36).substring(2) };
+                    }}
+                  />
+                </ProtectedRoute>
+              }
+            />
+            <Route path="*" element={<Navigate to="/" replace />} />
+          </Routes>
+          <ShortcutHelp />
+          <ShortcutFeedback />
+        </ShortcutProvider>
         </BrowserRouter>
         <ToastContainer />
       </AuthProvider>

--- a/frontend/src/components/ShortcutHelp.tsx
+++ b/frontend/src/components/ShortcutHelp.tsx
@@ -1,0 +1,291 @@
+import React, { useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  IconButton,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import {
+  Close as CloseIcon,
+  Keyboard as KeyboardIcon,
+  RestartAlt as RestartAltIcon,
+  Save as SaveIcon,
+} from '@mui/icons-material';
+import { ShortcutId, SHORTCUT_CATEGORIES, getShortcutCategoryLabel, getShortcutDisplayLabel } from '../shortcuts';
+import { useShortcutContext } from '../contexts/ShortcutContext';
+
+interface ShortcutRecorderProps {
+  shortcutId: ShortcutId;
+}
+
+const keyFromEvent = (event: React.KeyboardEvent<HTMLInputElement>): string => {
+  const key = event.key === ' ' ? 'space' : event.key.toLowerCase();
+  if (['control', 'shift', 'alt', 'meta'].includes(key)) return '';
+
+  const parts = [
+    event.ctrlKey ? 'ctrl' : '',
+    event.metaKey ? 'meta' : '',
+    event.altKey ? 'alt' : '',
+    event.shiftKey ? 'shift' : '',
+    key,
+  ].filter(Boolean);
+
+  return parts.join('+');
+};
+
+const ShortcutRecorder: React.FC<ShortcutRecorderProps> = ({ shortcutId }) => {
+  const {
+    getShortcutBinding,
+    resetShortcutBinding,
+    setShortcutBinding,
+  } = useShortcutContext();
+  const [draft, setDraft] = useState('');
+  const [message, setMessage] = useState<string | null>(null);
+
+  const currentBinding = getShortcutBinding(shortcutId);
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    if (event.key === 'Escape') {
+      setDraft('');
+      setMessage(null);
+      return;
+    }
+
+    const next = keyFromEvent(event);
+    if (!next) return;
+    setDraft(next);
+    setMessage(null);
+  };
+
+  const handleSave = () => {
+    const result = setShortcutBinding(shortcutId, { keys: draft });
+    if (result.ok) {
+      setDraft('');
+      setMessage('Saved');
+      return;
+    }
+    setMessage(result.error ?? 'Shortcut could not be saved.');
+  };
+
+  const handleReset = () => {
+    resetShortcutBinding(shortcutId);
+    setDraft('');
+    setMessage('Reset to default');
+  };
+
+  return (
+    <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} alignItems={{ xs: 'stretch', sm: 'center' }}>
+      <TextField
+        value={draft || getShortcutDisplayLabel(currentBinding)}
+        onKeyDown={handleKeyDown}
+        size="small"
+        inputProps={{
+          'aria-label': `Record shortcut for ${shortcutId}`,
+          readOnly: true,
+        }}
+        sx={{ minWidth: 180 }}
+      />
+      <Tooltip title="Save shortcut">
+        <span>
+          <IconButton
+            aria-label={`Save shortcut for ${shortcutId}`}
+            disabled={!draft}
+            onClick={handleSave}
+            size="small"
+          >
+            <SaveIcon fontSize="small" />
+          </IconButton>
+        </span>
+      </Tooltip>
+      <Tooltip title="Reset shortcut">
+        <IconButton
+          aria-label={`Reset shortcut for ${shortcutId}`}
+          onClick={handleReset}
+          size="small"
+        >
+          <RestartAltIcon fontSize="small" />
+        </IconButton>
+      </Tooltip>
+      {message && (
+        <Typography
+          color={message === 'Saved' || message === 'Reset to default' ? 'success.main' : 'error.main'}
+          variant="caption"
+        >
+          {message}
+        </Typography>
+      )}
+    </Stack>
+  );
+};
+
+export const ShortcutHelp: React.FC = () => {
+  const {
+    closeHelp,
+    customBindings,
+    getShortcutBinding,
+    helpOpen,
+    resetAllShortcutBindings,
+    shortcuts,
+  } = useShortcutContext();
+
+  const groupedShortcuts = useMemo(
+    () =>
+      SHORTCUT_CATEGORIES.map((category) => ({
+        ...category,
+        shortcuts: shortcuts.filter((shortcut) => shortcut.category === category.id),
+      })).filter((category) => category.shortcuts.length > 0),
+    [shortcuts]
+  );
+
+  return (
+    <Dialog
+      aria-labelledby="shortcut-help-title"
+      fullWidth
+      maxWidth="md"
+      onClose={closeHelp}
+      open={helpOpen}
+    >
+      <DialogTitle id="shortcut-help-title" sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <KeyboardIcon color="primary" />
+        Keyboard Shortcuts
+        <IconButton
+          aria-label="Close shortcut help"
+          onClick={closeHelp}
+          sx={{ ml: 'auto' }}
+        >
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent dividers>
+        <Alert severity="info" sx={{ mb: 3 }}>
+          Shortcuts pause while you type in form fields. Existing buttons, links, and tabs remain available for every action.
+        </Alert>
+
+        <Stack spacing={3}>
+          {groupedShortcuts.map((category) => (
+            <Box key={category.id}>
+              <Typography variant="h6" sx={{ mb: 1, fontWeight: 700 }}>
+                {category.label}
+              </Typography>
+              <TableContainer component={Paper} variant="outlined">
+                <Table size="small" aria-label={`${getShortcutCategoryLabel(category.id)} shortcuts`}>
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>Action</TableCell>
+                      <TableCell>Shortcut</TableCell>
+                      <TableCell>Scope</TableCell>
+                      <TableCell>Customize</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {category.shortcuts.map((shortcut) => {
+                      const binding = getShortcutBinding(shortcut.id);
+                      const isCustomized = Boolean(customBindings[shortcut.id]);
+
+                      return (
+                        <TableRow key={shortcut.id}>
+                          <TableCell>
+                            <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                              {shortcut.title}
+                            </Typography>
+                            <Typography color="text.secondary" variant="caption">
+                              {shortcut.description}
+                            </Typography>
+                          </TableCell>
+                          <TableCell>
+                            <Chip
+                              component="kbd"
+                              label={getShortcutDisplayLabel(binding)}
+                              size="small"
+                              variant={isCustomized ? 'filled' : 'outlined'}
+                            />
+                          </TableCell>
+                          <TableCell>
+                            <Chip label={shortcut.scope} size="small" variant="outlined" />
+                          </TableCell>
+                          <TableCell>
+                            <ShortcutRecorder shortcutId={shortcut.id} />
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </TableContainer>
+            </Box>
+          ))}
+        </Stack>
+
+        <Divider sx={{ my: 3 }} />
+        <Typography color="text.secondary" variant="body2">
+          Avoid browser-owned shortcuts such as refresh, print, bookmark, address bar, and tab controls. The shortcut recorder blocks those combinations and any duplicate app bindings.
+        </Typography>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={resetAllShortcutBindings} startIcon={<RestartAltIcon />}>
+          Reset All
+        </Button>
+        <Button onClick={closeHelp} variant="contained">
+          Done
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export const ShortcutFeedback: React.FC = () => {
+  const { feedback } = useShortcutContext();
+
+  if (!feedback) return null;
+
+  return (
+    <Box
+      aria-live="polite"
+      role="status"
+      sx={{
+        position: 'fixed',
+        left: '50%',
+        bottom: 24,
+        transform: 'translateX(-50%)',
+        zIndex: (theme) => theme.zIndex.snackbar + 1,
+        bgcolor: 'background.paper',
+        color: 'text.primary',
+        border: '1px solid',
+        borderColor: 'divider',
+        borderRadius: 1,
+        boxShadow: 4,
+        px: 2,
+        py: 1,
+      }}
+    >
+      <Typography variant="body2" sx={{ fontWeight: 700 }}>
+        {feedback.title}
+      </Typography>
+      <Typography color="text.secondary" variant="caption">
+        {feedback.label}
+      </Typography>
+    </Box>
+  );
+};
+
+export default ShortcutHelp;

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -2,13 +2,16 @@ import React from 'react';
 import { IconButton, Tooltip } from '@mui/material';
 import { DarkMode, LightMode } from '@mui/icons-material';
 import { useThemeMode } from '../contexts/ThemeContext';
+import { useShortcutLabel } from '../hooks/useKeyboardShortcuts';
 
 export const ThemeToggle: React.FC = () => {
   const { mode, toggleTheme } = useThemeMode();
+  const shortcutLabel = useShortcutLabel('action.theme.toggle');
 
   return (
-    <Tooltip title={`Switch to ${mode === 'light' ? 'dark' : 'light'} mode (Ctrl+D)`}>
+    <Tooltip title={`Switch to ${mode === 'light' ? 'dark' : 'light'} mode (${shortcutLabel})`}>
       <IconButton
+        aria-keyshortcuts={shortcutLabel}
         onClick={toggleTheme}
         sx={{
           color: 'rgba(255,255,255,0.8)',

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -33,6 +33,7 @@ export { AnalyticsDashboard } from './AnalyticsDashboard';
 // Toast
 export { default as Toast } from './Toast';
 export { default as ToastContainer } from './ToastContainer';
+export { default as ShortcutHelp, ShortcutFeedback } from './ShortcutHelp';
 
 // File Upload
 export { default as FileUpload } from './FileUpload';

--- a/frontend/src/contexts/ShortcutContext.tsx
+++ b/frontend/src/contexts/ShortcutContext.tsx
@@ -1,0 +1,235 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { HotkeysProvider } from 'react-hotkeys-hook';
+import {
+  DEFAULT_SHORTCUTS,
+  SHORTCUT_STORAGE_KEY,
+  ShortcutBinding,
+  ShortcutConflict,
+  ShortcutDefinition,
+  ShortcutId,
+  expandsToReservedShortcut,
+  findShortcutConflict,
+  getDefaultShortcut,
+  normalizeShortcutKeys,
+} from '../shortcuts';
+import { storageGet, storageSet } from '../utils/storage';
+
+type ShortcutBindings = Partial<Record<ShortcutId, ShortcutBinding>>;
+
+interface ShortcutFeedback {
+  id: ShortcutId;
+  label: string;
+  title: string;
+}
+
+interface ShortcutUpdateResult {
+  ok: boolean;
+  error?: string;
+  conflict?: ShortcutConflict;
+}
+
+interface ShortcutContextValue {
+  shortcuts: ShortcutDefinition[];
+  customBindings: ShortcutBindings;
+  helpOpen: boolean;
+  feedback: ShortcutFeedback | null;
+  openHelp: () => void;
+  closeHelp: () => void;
+  registerShortcut: (shortcut: ShortcutDefinition) => void;
+  unregisterShortcut: (id: ShortcutId) => void;
+  getShortcutBinding: (id: ShortcutId) => ShortcutBinding;
+  setShortcutBinding: (id: ShortcutId, binding: ShortcutBinding) => ShortcutUpdateResult;
+  resetShortcutBinding: (id: ShortcutId) => void;
+  resetAllShortcutBindings: () => void;
+  reportShortcutPressed: (id: ShortcutId) => void;
+}
+
+const ShortcutContext = createContext<ShortcutContextValue | undefined>(undefined);
+
+const readStoredBindings = (): ShortcutBindings => {
+  const stored = storageGet<unknown>(SHORTCUT_STORAGE_KEY);
+  if (!stored || typeof stored !== 'object' || Array.isArray(stored)) return {};
+
+  const bindings: ShortcutBindings = {};
+  Object.entries(stored as Record<string, unknown>).forEach(([id, value]) => {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return;
+    const binding = value as Record<string, unknown>;
+    if (typeof binding.keys !== 'string') return;
+    const knownShortcut = getDefaultShortcut(id as ShortcutId);
+    if (!knownShortcut) return;
+    bindings[id as ShortcutId] = {
+      keys: binding.keys,
+      label: typeof binding.label === 'string' ? binding.label : undefined,
+    };
+  });
+
+  return bindings;
+};
+
+export const ShortcutProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [registeredShortcuts, setRegisteredShortcuts] = useState<Record<string, ShortcutDefinition>>({});
+  const [customBindings, setCustomBindings] = useState<ShortcutBindings>(readStoredBindings);
+  const [helpOpen, setHelpOpen] = useState(false);
+  const [feedback, setFeedback] = useState<ShortcutFeedback | null>(null);
+  const feedbackTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    storageSet(SHORTCUT_STORAGE_KEY, customBindings);
+  }, [customBindings]);
+
+  useEffect(() => {
+    return () => {
+      if (feedbackTimer.current) clearTimeout(feedbackTimer.current);
+    };
+  }, []);
+
+  const shortcuts = useMemo(() => {
+    const byId = new Map<ShortcutId, ShortcutDefinition>();
+    DEFAULT_SHORTCUTS.forEach((shortcut) => byId.set(shortcut.id, shortcut));
+    Object.values(registeredShortcuts).forEach((shortcut) => byId.set(shortcut.id, shortcut));
+    return Array.from(byId.values());
+  }, [registeredShortcuts]);
+
+  const openHelp = useCallback(() => setHelpOpen(true), []);
+  const closeHelp = useCallback(() => setHelpOpen(false), []);
+
+  const registerShortcut = useCallback((shortcut: ShortcutDefinition) => {
+    setRegisteredShortcuts((current) => {
+      const existing = current[shortcut.id];
+      if (existing && existing.defaultBinding.keys === shortcut.defaultBinding.keys) return current;
+      return { ...current, [shortcut.id]: shortcut };
+    });
+  }, []);
+
+  const unregisterShortcut = useCallback((id: ShortcutId) => {
+    setRegisteredShortcuts((current) => {
+      if (!current[id]) return current;
+      const next = { ...current };
+      delete next[id];
+      return next;
+    });
+  }, []);
+
+  const getShortcutBinding = useCallback(
+    (id: ShortcutId): ShortcutBinding => {
+      const shortcut = shortcuts.find((candidate) => candidate.id === id) ?? getDefaultShortcut(id);
+      if (!shortcut) return { keys: '' };
+      return customBindings[id] ?? shortcut.defaultBinding;
+    },
+    [customBindings, shortcuts]
+  );
+
+  const setShortcutBinding = useCallback(
+    (id: ShortcutId, binding: ShortcutBinding): ShortcutUpdateResult => {
+      const keys = normalizeShortcutKeys(binding.keys);
+      if (!keys) return { ok: false, error: 'Enter a shortcut before saving.' };
+
+      if (expandsToReservedShortcut(keys)) {
+        return { ok: false, error: 'That shortcut is reserved by the browser or operating system.' };
+      }
+
+      const conflict = findShortcutConflict(id, keys, shortcuts, customBindings);
+      if (conflict) {
+        const conflictingShortcut = shortcuts.find((shortcut) => shortcut.id === conflict.conflictingId);
+        return {
+          ok: false,
+          error: `That shortcut is already used by ${conflictingShortcut?.title ?? conflict.conflictingId}.`,
+          conflict,
+        };
+      }
+
+      setCustomBindings((current) => ({
+        ...current,
+        [id]: {
+          keys,
+          label: binding.label,
+        },
+      }));
+
+      return { ok: true };
+    },
+    [customBindings, shortcuts]
+  );
+
+  const resetShortcutBinding = useCallback((id: ShortcutId) => {
+    setCustomBindings((current) => {
+      if (!current[id]) return current;
+      const next = { ...current };
+      delete next[id];
+      return next;
+    });
+  }, []);
+
+  const resetAllShortcutBindings = useCallback(() => {
+    setCustomBindings({});
+  }, []);
+
+  const reportShortcutPressed = useCallback(
+    (id: ShortcutId) => {
+      const shortcut = shortcuts.find((candidate) => candidate.id === id);
+      if (!shortcut) return;
+
+      const binding = getShortcutBinding(id);
+      setFeedback({ id, label: binding.label ?? binding.keys, title: shortcut.title });
+
+      if (feedbackTimer.current) clearTimeout(feedbackTimer.current);
+      feedbackTimer.current = setTimeout(() => setFeedback(null), 900);
+    },
+    [getShortcutBinding, shortcuts]
+  );
+
+  const value = useMemo<ShortcutContextValue>(
+    () => ({
+      shortcuts,
+      customBindings,
+      helpOpen,
+      feedback,
+      openHelp,
+      closeHelp,
+      registerShortcut,
+      unregisterShortcut,
+      getShortcutBinding,
+      setShortcutBinding,
+      resetShortcutBinding,
+      resetAllShortcutBindings,
+      reportShortcutPressed,
+    }),
+    [
+      shortcuts,
+      customBindings,
+      helpOpen,
+      feedback,
+      openHelp,
+      closeHelp,
+      registerShortcut,
+      unregisterShortcut,
+      getShortcutBinding,
+      setShortcutBinding,
+      resetShortcutBinding,
+      resetAllShortcutBindings,
+      reportShortcutPressed,
+    ]
+  );
+
+  return (
+    <HotkeysProvider initiallyActiveScopes={['global', 'dashboard', 'settings']}>
+      <ShortcutContext.Provider value={value}>{children}</ShortcutContext.Provider>
+    </HotkeysProvider>
+  );
+};
+
+export const useShortcutContext = (): ShortcutContextValue => {
+  const context = useContext(ShortcutContext);
+  if (!context) {
+    throw new Error('useShortcutContext must be used within ShortcutProvider');
+  }
+  return context;
+};

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -66,17 +66,6 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     setUserPreference(next);
   }, [mode]);
 
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if ((e.ctrlKey || e.metaKey) && e.key === 'd') {
-        e.preventDefault();
-        toggleTheme();
-      }
-    };
-    window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
-  }, [toggleTheme]);
-
   const activeTheme = mode === 'light' ? lightTheme : darkTheme;
 
   const contextValue = useMemo(() => ({ mode, userPreference, setTheme, toggleTheme }), [mode, userPreference, setTheme, toggleTheme]);

--- a/frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,89 @@
+import { useCallback, useEffect, useMemo } from 'react';
+import { useHotkeys } from 'react-hotkeys-hook';
+import { ShortcutDefinition, getShortcutDisplayLabel } from '../shortcuts';
+import { useShortcutContext } from '../contexts/ShortcutContext';
+
+interface UseKeyboardShortcutOptions {
+  enabled?: boolean;
+  allowInFormFields?: boolean;
+}
+
+const INTERACTIVE_ROLES = new Set([
+  'combobox',
+  'menuitem',
+  'menuitemcheckbox',
+  'menuitemradio',
+  'option',
+  'radio',
+  'searchbox',
+  'slider',
+  'spinbutton',
+  'textbox',
+]);
+
+const isEditableTarget = (target: EventTarget | null): boolean => {
+  if (!(target instanceof HTMLElement)) return false;
+
+  const tagName = target.tagName.toLowerCase();
+  if (tagName === 'input' || tagName === 'textarea' || tagName === 'select') return true;
+  if (target.isContentEditable) return true;
+
+  const role = target.getAttribute('role');
+  return role ? INTERACTIVE_ROLES.has(role) : false;
+};
+
+export const useKeyboardShortcut = (
+  shortcut: ShortcutDefinition,
+  handler: (event: KeyboardEvent) => void,
+  options: UseKeyboardShortcutOptions = {}
+): void => {
+  const {
+    getShortcutBinding,
+    registerShortcut,
+    reportShortcutPressed,
+    unregisterShortcut,
+  } = useShortcutContext();
+
+  const enabled = options.enabled ?? true;
+  const binding = getShortcutBinding(shortcut.id);
+  const keys = binding.keys || shortcut.defaultBinding.keys;
+  const allowInFormFields = options.allowInFormFields ?? shortcut.allowInFormFields ?? false;
+
+  useEffect(() => {
+    registerShortcut(shortcut);
+    return () => unregisterShortcut(shortcut.id);
+  }, [registerShortcut, shortcut, unregisterShortcut]);
+
+  const callback = useCallback(
+    (event: KeyboardEvent) => {
+      if (!enabled) return;
+      handler(event);
+      reportShortcutPressed(shortcut.id);
+    },
+    [enabled, handler, reportShortcutPressed, shortcut.id]
+  );
+
+  const hotkeyOptions = useMemo(
+    () => ({
+      enabled,
+      enableOnFormTags: allowInFormFields,
+      enableOnContentEditable: allowInFormFields,
+      preventDefault: shortcut.preventDefault ?? true,
+      description: shortcut.description,
+      delimiter: '|',
+      scopes: shortcut.scope,
+      sequenceSplitKey: '>',
+      ignoreEventWhen: (event: KeyboardEvent) =>
+        !allowInFormFields && isEditableTarget(event.target),
+    }),
+    [allowInFormFields, enabled, shortcut.description, shortcut.preventDefault, shortcut.scope]
+  );
+
+  useHotkeys(keys, callback, hotkeyOptions, [callback, keys, hotkeyOptions]);
+};
+
+export const useShortcutLabel = (shortcutId: ShortcutDefinition['id']): string => {
+  const { getShortcutBinding } = useShortcutContext();
+  const binding = getShortcutBinding(shortcutId);
+  return getShortcutDisplayLabel(binding);
+};

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -6,7 +6,8 @@ import {
   Tabs,
   Tab,
   Breadcrumbs,
-  Link
+  Link,
+  Button
 } from '@mui/material';
 import {
   Settings as SettingsIcon,
@@ -20,6 +21,8 @@ import AccountSettings from '../components/settings/AccountSettings';
 import NotificationSettings from '../components/settings/NotificationSettings';
 import SecuritySettings from '../components/settings/SecuritySettings';
 import ApiKeysSettings from '../components/settings/ApiKeysSettings';
+import { useShortcutContext } from '../contexts/ShortcutContext';
+import { useShortcutLabel } from '../hooks/useKeyboardShortcuts';
 
 interface TabPanelProps {
   children?: React.ReactNode;
@@ -109,6 +112,8 @@ export const Settings: React.FC<SettingsPageProps> = ({
   onRegenerateApiKey
 }) => {
   const [activeTab, setActiveTab] = useState(0);
+  const { openHelp } = useShortcutContext();
+  const shortcutSettingsLabel = useShortcutLabel('settings.shortcuts');
 
   return (
     <Box sx={{ minHeight: '100vh', bgcolor: 'background.default', p: { xs: 2, md: 4 } }}>
@@ -120,11 +125,20 @@ export const Settings: React.FC<SettingsPageProps> = ({
           <Typography color="text.primary">Settings</Typography>
         </Breadcrumbs>
 
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 4 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 4, flexWrap: 'wrap' }}>
           <SettingsIcon sx={{ fontSize: 32, color: 'text.primary' }} />
           <Typography variant="h4" sx={{ fontWeight: 700, color: 'text.primary' }}>
             Settings
           </Typography>
+          <Button
+            aria-keyshortcuts={shortcutSettingsLabel}
+            onClick={openHelp}
+            size="small"
+            sx={{ ml: { xs: 0, sm: 'auto' } }}
+            variant="outlined"
+          >
+            Keyboard Shortcuts ({shortcutSettingsLabel})
+          </Button>
         </Box>
 
         <Paper sx={{ borderRadius: 3, overflow: 'hidden' }}>

--- a/frontend/src/shortcuts/__tests__/index.test.ts
+++ b/frontend/src/shortcuts/__tests__/index.test.ts
@@ -1,0 +1,39 @@
+import {
+  DEFAULT_SHORTCUTS,
+  expandsToReservedShortcut,
+  findShortcutConflict,
+  getShortcutDisplayLabel,
+  normalizeShortcutKeys,
+} from '../index';
+
+describe('keyboard shortcut registry', () => {
+  it('normalizes modifier order and aliases', () => {
+    expect(normalizeShortcutKeys('Shift+Command+L')).toBe('meta+shift+l');
+    expect(normalizeShortcutKeys('h>g')).toBe('h>g');
+  });
+
+  it('formats labels for display', () => {
+    expect(getShortcutDisplayLabel({ keys: 'mod+shift+l' })).toBe('Ctrl/Command+Shift+L');
+    expect(getShortcutDisplayLabel({ keys: 'g>h', label: 'G then H' })).toBe('G then H');
+  });
+
+  it('detects browser-reserved shortcuts', () => {
+    expect(expandsToReservedShortcut('ctrl+d')).toBe(true);
+    expect(expandsToReservedShortcut('mod+shift+l')).toBe(false);
+  });
+
+  it('detects app shortcut conflicts', () => {
+    const conflict = findShortcutConflict(
+      'navigation.profile',
+      'g>h',
+      DEFAULT_SHORTCUTS,
+      {}
+    );
+
+    expect(conflict).toEqual({
+      shortcutId: 'navigation.profile',
+      conflictingId: 'navigation.dashboard',
+      keys: 'g>h',
+    });
+  });
+});

--- a/frontend/src/shortcuts/index.ts
+++ b/frontend/src/shortcuts/index.ts
@@ -1,0 +1,271 @@
+export type ShortcutCategory = 'navigation' | 'action' | 'search' | 'settings' | 'help';
+
+export type ShortcutScope = 'global' | 'dashboard' | 'settings';
+
+export type ShortcutId =
+  | 'help.open'
+  | 'navigation.dashboard'
+  | 'navigation.profile'
+  | 'navigation.settings'
+  | 'dashboard.analytics'
+  | 'dashboard.forms'
+  | 'dashboard.visualization'
+  | 'search.focus'
+  | 'settings.shortcuts'
+  | 'action.theme.toggle'
+  | 'action.signout';
+
+export interface ShortcutBinding {
+  keys: string;
+  label?: string;
+}
+
+export interface ShortcutDefinition {
+  id: ShortcutId;
+  category: ShortcutCategory;
+  scope: ShortcutScope;
+  title: string;
+  description: string;
+  defaultBinding: ShortcutBinding;
+  preventDefault?: boolean;
+  allowInFormFields?: boolean;
+}
+
+export interface ShortcutConflict {
+  shortcutId: ShortcutId;
+  conflictingId: ShortcutId;
+  keys: string;
+}
+
+export const SHORTCUT_STORAGE_KEY = 'chenaikit_shortcuts';
+
+const CATEGORY_LABELS: Record<ShortcutCategory, string> = {
+  navigation: 'Navigation',
+  action: 'Actions',
+  search: 'Search',
+  settings: 'Settings',
+  help: 'Help',
+};
+
+export const SHORTCUT_CATEGORIES = Object.entries(CATEGORY_LABELS).map(([id, label]) => ({
+  id: id as ShortcutCategory,
+  label,
+}));
+
+export const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
+  {
+    id: 'help.open',
+    category: 'help',
+    scope: 'global',
+    title: 'Open shortcut help',
+    description: 'Show the keyboard shortcut cheat sheet and customization controls.',
+    defaultBinding: { keys: 'shift+/', label: '?' },
+    preventDefault: true,
+  },
+  {
+    id: 'navigation.dashboard',
+    category: 'navigation',
+    scope: 'global',
+    title: 'Go to dashboard',
+    description: 'Navigate to the main dashboard.',
+    defaultBinding: { keys: 'g>h', label: 'G then H' },
+    preventDefault: true,
+  },
+  {
+    id: 'navigation.profile',
+    category: 'navigation',
+    scope: 'global',
+    title: 'Go to profile',
+    description: 'Navigate to the profile page.',
+    defaultBinding: { keys: 'g>p', label: 'G then P' },
+    preventDefault: true,
+  },
+  {
+    id: 'navigation.settings',
+    category: 'navigation',
+    scope: 'global',
+    title: 'Go to settings',
+    description: 'Navigate to the settings page.',
+    defaultBinding: { keys: 'g>s', label: 'G then S' },
+    preventDefault: true,
+  },
+  {
+    id: 'dashboard.analytics',
+    category: 'navigation',
+    scope: 'dashboard',
+    title: 'Show analytics dashboard',
+    description: 'Switch the dashboard to analytics.',
+    defaultBinding: { keys: 'alt+1', label: 'Alt+1' },
+    preventDefault: true,
+  },
+  {
+    id: 'dashboard.forms',
+    category: 'navigation',
+    scope: 'dashboard',
+    title: 'Show forms',
+    description: 'Switch the dashboard to forms.',
+    defaultBinding: { keys: 'alt+2', label: 'Alt+2' },
+    preventDefault: true,
+  },
+  {
+    id: 'dashboard.visualization',
+    category: 'navigation',
+    scope: 'dashboard',
+    title: 'Show visualization sandbox',
+    description: 'Switch the dashboard to the visualization sandbox.',
+    defaultBinding: { keys: 'alt+3', label: 'Alt+3' },
+    preventDefault: true,
+  },
+  {
+    id: 'search.focus',
+    category: 'search',
+    scope: 'global',
+    title: 'Focus search',
+    description: 'Move focus to the first search field on the current page.',
+    defaultBinding: { keys: '/', label: '/' },
+    preventDefault: true,
+  },
+  {
+    id: 'settings.shortcuts',
+    category: 'settings',
+    scope: 'global',
+    title: 'Customize shortcuts',
+    description: 'Open the shortcut settings view.',
+    defaultBinding: { keys: 'mod+shift+,', label: 'Ctrl/Command+Shift+,' },
+    preventDefault: true,
+  },
+  {
+    id: 'action.theme.toggle',
+    category: 'action',
+    scope: 'global',
+    title: 'Toggle theme',
+    description: 'Switch between light and dark mode.',
+    defaultBinding: { keys: 'mod+shift+l', label: 'Ctrl/Command+Shift+L' },
+    preventDefault: true,
+  },
+  {
+    id: 'action.signout',
+    category: 'action',
+    scope: 'global',
+    title: 'Sign out',
+    description: 'Sign out of the current session.',
+    defaultBinding: { keys: 'mod+shift+q', label: 'Ctrl/Command+Shift+Q' },
+    preventDefault: true,
+  },
+];
+
+const BROWSER_RESERVED_SHORTCUTS = new Set([
+  'ctrl+d',
+  'meta+d',
+  'ctrl+l',
+  'meta+l',
+  'ctrl+n',
+  'meta+n',
+  'ctrl+p',
+  'meta+p',
+  'ctrl+r',
+  'meta+r',
+  'ctrl+s',
+  'meta+s',
+  'ctrl+t',
+  'meta+t',
+  'ctrl+w',
+  'meta+w',
+  'alt+left',
+  'alt+right',
+  'ctrl+tab',
+  'ctrl+shift+tab',
+  'meta+tab',
+  'meta+shift+tab',
+]);
+
+const KEY_ALIASES: Record<string, string> = {
+  cmd: 'meta',
+  command: 'meta',
+  control: 'ctrl',
+  option: 'alt',
+  escape: 'esc',
+  return: 'enter',
+  plus: '+',
+};
+
+const MODIFIER_ORDER = ['ctrl', 'meta', 'mod', 'alt', 'shift'];
+
+export const getShortcutCategoryLabel = (category: ShortcutCategory): string =>
+  CATEGORY_LABELS[category];
+
+export const normalizeShortcutKeys = (keys: string): string => {
+  return keys
+    .split('>')
+    .map((step) => {
+      const parts = step
+        .split('+')
+        .map((part) => part.trim().toLowerCase())
+        .filter(Boolean)
+        .map((part) => KEY_ALIASES[part] ?? part);
+
+      const modifiers = MODIFIER_ORDER.filter((modifier) => parts.includes(modifier));
+      const regularKeys = parts.filter((part) => !MODIFIER_ORDER.includes(part)).sort();
+      return [...modifiers, ...regularKeys].join('+');
+    })
+    .join('>');
+};
+
+export const getShortcutDisplayLabel = (binding: ShortcutBinding): string => {
+  if (binding.label) return binding.label;
+
+  return binding.keys
+    .split('>')
+    .map((step) =>
+      step
+        .split('+')
+        .map((part) => {
+          const normalized = part.trim().toLowerCase();
+          if (normalized === 'mod') return 'Ctrl/Command';
+          if (normalized === 'ctrl') return 'Ctrl';
+          if (normalized === 'meta') return 'Command';
+          if (normalized === 'alt') return 'Alt';
+          if (normalized === 'shift') return 'Shift';
+          if (normalized === 'esc') return 'Esc';
+          return normalized.length === 1 ? normalized.toUpperCase() : normalized;
+        })
+        .join('+')
+    )
+    .join(' then ');
+};
+
+export const expandsToReservedShortcut = (keys: string): boolean => {
+  const normalized = normalizeShortcutKeys(keys);
+  const candidates = normalized.includes('mod')
+    ? [normalized.replace('mod', 'ctrl'), normalized.replace('mod', 'meta')]
+    : [normalized];
+
+  return candidates.some((candidate) => BROWSER_RESERVED_SHORTCUTS.has(candidate));
+};
+
+export const findShortcutConflict = (
+  shortcutId: ShortcutId,
+  keys: string,
+  shortcuts: ShortcutDefinition[],
+  customBindings: Partial<Record<ShortcutId, ShortcutBinding>>
+): ShortcutConflict | null => {
+  const normalized = normalizeShortcutKeys(keys);
+
+  for (const shortcut of shortcuts) {
+    if (shortcut.id === shortcutId) continue;
+
+    const candidate = customBindings[shortcut.id] ?? shortcut.defaultBinding;
+    if (normalizeShortcutKeys(candidate.keys) === normalized) {
+      return {
+        shortcutId,
+        conflictingId: shortcut.id,
+        keys,
+      };
+    }
+  }
+
+  return null;
+};
+
+export const getDefaultShortcut = (id: ShortcutId): ShortcutDefinition | undefined =>
+  DEFAULT_SHORTCUTS.find((shortcut) => shortcut.id === id);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -388,6 +388,9 @@ importers:
       react-hook-form:
         specifier: 7.54.2
         version: 7.54.2(react@18.3.1)
+      react-hotkeys-hook:
+        specifier: ^5.3.2
+        version: 5.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-i18next:
         specifier: ^13.5.0
         version: 13.5.0(i18next@23.16.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.86.0(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1)
@@ -8331,6 +8334,12 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
+
+  react-hotkeys-hook@5.3.2:
+    resolution: {integrity: sha512-DDDy9xK6mbTQ6aPlQvIl0dA/a90T/AWml4Rm21JXFDLlRHalIg4/Rv3equUQYs5xPTWq+oEl6RD7mi/nBpU3Uw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
 
   react-i18next@13.5.0:
     resolution: {integrity: sha512-CFJ5NDGJ2MUyBohEHxljOq/39NQ972rh1ajnadG9BjTk+UXbHLq4z5DKEbEQBDoIhUmmbuS/fIMJKo6VOax1HA==}
@@ -19909,6 +19918,11 @@ snapshots:
   react-hook-form@7.54.2(react@18.3.1):
     dependencies:
       react: 18.3.1
+
+  react-hotkeys-hook@5.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   react-i18next@13.5.0(i18next@23.16.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.86.0(@babel/core@7.29.7)(@types/react@18.3.31)(react@18.3.1))(react@18.3.1):
     dependencies:


### PR DESCRIPTION
closes #167 

This PR closes issue #167 by adding a production-ready keyboard shortcut system to the frontend.

Previously, the application had no centralized keyboard shortcut support. Important workflows such as navigation, dashboard switching, theme toggling, sign out, search focus, and shortcut discovery required mouse interaction. That limited the experience for power users and made the UI less accessible for keyboard-only users.

The flow now works through a centralized shortcut registry, provider, and hook:

- `frontend/src/shortcuts/index.ts` defines all shortcut metadata, categories, default bindings, browser-reserved shortcut checks, display labels, and conflict detection.
- `frontend/src/contexts/ShortcutContext.tsx` owns runtime shortcut state, persisted custom bindings, the shortcut help modal state, and visual feedback after shortcut activation.
- `frontend/src/hooks/useKeyboardShortcuts.ts` wraps `react-hotkeys-hook` so components can bind shortcuts without duplicating safety logic.
- `frontend/src/components/ShortcutHelp.tsx` provides the cheat sheet and customization UI.

This matters because shortcuts are now discoverable, conflict-safe, customizable, and accessible. The implementation avoids browser-owned shortcuts, suppresses shortcut handling while users type in editable fields, and keeps all existing button/link workflows available as alternatives.

# Changes Made

- Added `react-hotkeys-hook` for declarative keyboard shortcut handling for #167.
- Added a typed shortcut registry with categories for navigation, actions, search, settings, and help.
- Added default shortcuts for:
  - Opening shortcut help.
  - Navigating to dashboard, profile, and settings.
  - Switching dashboard tabs.
  - Focusing search fields.
  - Opening shortcut customization.
  - Toggling theme.
  - Signing out.
- Added conflict detection for custom shortcut bindings.
- Added browser-reserved shortcut protection to avoid hijacking common browser/system shortcuts.
- Added localStorage-backed shortcut customization through the existing frontend storage helper.
- Added an accessible shortcut help modal and cheat sheet.
- Added visual feedback when a shortcut runs.
- Added shortcut labels to dashboard controls, settings entry point, sign out tooltip, and theme toggle tooltip.
- Removed the previous hard-coded `Ctrl+D` theme shortcut because it conflicts with browser bookmarking.
- Added focused registry tests for shortcut normalization, display labels, reserved shortcut detection, and conflict detection.
