### PR TITLE
feat: ML model versioning & A/B testing framework

### DIFF
--- a/.github/workflows/model-deployment.yml
+++ b/.github/workflows/model-deployment.yml
@@ -1,0 +1,150 @@
+name: Model Training, Validation & Deployment
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'ml/**'
+      - 'packages/chenai-mlflow/**'
+  workflow_dispatch:
+    inputs:
+      model_task:
+        description: 'Which model to train (credit_scoring | fraud_detection)'
+        required: true
+        default: 'credit_scoring'
+      promote:
+        description: 'Promote to production after validation passes'
+        required: false
+        default: 'false'
+
+jobs:
+  train:
+    runs-on: ubuntu-latest
+    outputs:
+      artifact-name: ${{ steps.train.outputs.artifact_name }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: ml/requirements.txt
+
+      - name: Install ML dependencies
+        run: pip install -r ml/requirements.txt
+
+      - name: Generate synthetic training data
+        run: python ml/data/generate_synthetic_data.py
+
+      - name: Preprocess data
+        run: python ml/data/preprocessing.py
+
+      - name: Train credit scoring model
+        if: ${{ github.event.inputs.model_task == 'credit_scoring' || github.event.inputs.model_task == '' }}
+        id: train
+        run: |
+          python ml/training/train_credit_score.py
+          echo "artifact_name=credit-scoring-models" >> "$GITHUB_OUTPUT"
+
+      - name: Train fraud detection model
+        if: ${{ github.event.inputs.model_task == 'fraud_detection' }}
+        run: python ml/training/train_fraud_detector.py
+
+      - name: Upload trained model artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: trained-models
+          path: ml/models/**
+          retention-days: 30
+
+  validate:
+    needs: train
+    runs-on: ubuntu-latest
+    outputs:
+      validation-passed: ${{ steps.validate.outputs.passed }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: ml/requirements.txt
+
+      - name: Install ML dependencies
+        run: pip install -r ml/requirements.txt
+
+      - name: Download trained model artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: trained-models
+          path: ml/models
+
+      - name: Run model evaluation metrics
+        id: validate
+        run: |
+          python ml/evaluation/metrics.py
+          echo "passed=true" >> "$GITHUB_OUTPUT"
+
+  register-and-deploy:
+    needs: validate
+    if: needs.validate.outputs.validation-passed == 'true'
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install chenai-mlflow SDK
+        run: pip install -e packages/chenai-mlflow
+
+      - name: Download trained model artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: trained-models
+          path: ml/models
+
+      - name: Register model version with the registry
+        env:
+          CHENAIKIT_API_URL: ${{ secrets.CHENAIKIT_API_URL }}
+        run: |
+          python - <<'PYEOF'
+          import os
+          from pathlib import Path
+          from chenai_mlflow import ModelRegistryClient
+
+          client = ModelRegistryClient(base_url=os.environ.get("CHENAIKIT_API_URL"))
+
+          model_files = list(Path("ml/models").glob("*.pkl")) + list(Path("ml/models").glob("*.joblib"))
+          if not model_files:
+              raise SystemExit("No trained model artifacts found to register")
+
+          artifact = model_files[0]
+          model = client.get_or_create_model("credit-scoring", task_type="credit_scoring")
+
+          version = client.register_version(
+              model_id=model["id"],
+              version=os.environ.get("GITHUB_SHA", "dev")[:12],
+              artifact_path=str(artifact),
+              code_commit=os.environ.get("GITHUB_SHA"),
+              training_run_id=os.environ.get("GITHUB_RUN_ID"),
+          )
+          print(f"Registered version {version['id']} (stage={version['stage']})")
+          PYEOF
+
+      - name: Promote to production (manual approval gate)
+        if: ${{ github.event.inputs.promote == 'true' }}
+        env:
+          CHENAIKIT_API_URL: ${{ secrets.CHENAIKIT_API_URL }}
+        run: |
+          echo "Promotion requires an explicit approvedBy actor; run via the registry dashboard or API once staging validation is confirmed."

--- a/backend/prisma/migrations/20260720000000_ml_model_registry_and_experiments/migration.sql
+++ b/backend/prisma/migrations/20260720000000_ml_model_registry_and_experiments/migration.sql
@@ -1,0 +1,174 @@
+-- CreateTable
+CREATE TABLE "ml_models" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL DEFAULT '',
+    "taskType" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "ml_model_versions" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "modelId" TEXT NOT NULL,
+    "version" TEXT NOT NULL,
+    "stage" TEXT NOT NULL DEFAULT 'staging',
+    "artifactUri" TEXT NOT NULL,
+    "contentHash" TEXT NOT NULL,
+    "frameworkVersion" TEXT,
+    "accuracy" REAL,
+    "precision" REAL,
+    "recall" REAL,
+    "f1Score" REAL,
+    "auc" REAL,
+    "trainingDataUri" TEXT,
+    "trainingDataHash" TEXT,
+    "hyperparameters" TEXT NOT NULL DEFAULT '{}',
+    "metadata" TEXT NOT NULL DEFAULT '{}',
+    "datasetVersion" TEXT,
+    "codeCommit" TEXT,
+    "trainingRunId" TEXT,
+    "approvedBy" TEXT,
+    "approvedAt" DATETIME,
+    "promotedAt" DATETIME,
+    "archivedAt" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "ml_model_versions_modelId_fkey" FOREIGN KEY ("modelId") REFERENCES "ml_models" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "experiments" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "key" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL DEFAULT '',
+    "modelId" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'draft',
+    "hypothesis" TEXT NOT NULL DEFAULT '',
+    "metric" TEXT NOT NULL,
+    "minimumDetectableEffect" REAL,
+    "significanceLevel" REAL NOT NULL DEFAULT 0.05,
+    "power" REAL NOT NULL DEFAULT 0.8,
+    "bonferroniCorrection" BOOLEAN NOT NULL DEFAULT false,
+    "canaryThresholdPct" REAL NOT NULL DEFAULT 5.0,
+    "canaryWindowHours" INTEGER NOT NULL DEFAULT 24,
+    "startedAt" DATETIME,
+    "endedAt" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "experiments_modelId_fkey" FOREIGN KEY ("modelId") REFERENCES "ml_models" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "experiment_variants" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "experimentId" TEXT NOT NULL,
+    "modelVersionId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "isControl" BOOLEAN NOT NULL DEFAULT false,
+    "trafficWeight" REAL NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "experiment_variants_experimentId_fkey" FOREIGN KEY ("experimentId") REFERENCES "experiments" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "experiment_variants_modelVersionId_fkey" FOREIGN KEY ("modelVersionId") REFERENCES "ml_model_versions" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "experiment_assignments" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "experimentId" TEXT NOT NULL,
+    "variantId" TEXT NOT NULL,
+    "subjectId" TEXT NOT NULL,
+    "assignedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "experiment_assignments_experimentId_fkey" FOREIGN KEY ("experimentId") REFERENCES "experiments" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "experiment_assignments_variantId_fkey" FOREIGN KEY ("variantId") REFERENCES "experiment_variants" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "experiment_events" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "experimentId" TEXT NOT NULL,
+    "variantId" TEXT NOT NULL,
+    "subjectId" TEXT NOT NULL,
+    "eventType" TEXT NOT NULL,
+    "metricName" TEXT,
+    "metricValue" REAL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "experiment_events_experimentId_fkey" FOREIGN KEY ("experimentId") REFERENCES "experiments" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "experiment_events_variantId_fkey" FOREIGN KEY ("variantId") REFERENCES "experiment_variants" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "model_drift_checks" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "modelVersionId" TEXT NOT NULL,
+    "windowStart" DATETIME NOT NULL,
+    "windowEnd" DATETIME NOT NULL,
+    "baselineAuc" REAL NOT NULL,
+    "observedAuc" REAL NOT NULL,
+    "aucDrop" REAL NOT NULL,
+    "driftDetected" BOOLEAN NOT NULL DEFAULT false,
+    "alertSent" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "model_drift_checks_modelVersionId_fkey" FOREIGN KEY ("modelVersionId") REFERENCES "ml_model_versions" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ml_models_name_key" ON "ml_models"("name");
+
+-- CreateIndex
+CREATE INDEX "ml_models_taskType_idx" ON "ml_models"("taskType");
+
+-- CreateIndex
+CREATE INDEX "ml_model_versions_modelId_stage_idx" ON "ml_model_versions"("modelId", "stage");
+
+-- CreateIndex
+CREATE INDEX "ml_model_versions_contentHash_idx" ON "ml_model_versions"("contentHash");
+
+-- CreateIndex
+CREATE INDEX "ml_model_versions_stage_idx" ON "ml_model_versions"("stage");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ml_model_versions_modelId_version_key" ON "ml_model_versions"("modelId", "version");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "experiments_key_key" ON "experiments"("key");
+
+-- CreateIndex
+CREATE INDEX "experiments_modelId_idx" ON "experiments"("modelId");
+
+-- CreateIndex
+CREATE INDEX "experiments_status_idx" ON "experiments"("status");
+
+-- CreateIndex
+CREATE INDEX "experiment_variants_experimentId_idx" ON "experiment_variants"("experimentId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "experiment_variants_experimentId_name_key" ON "experiment_variants"("experimentId", "name");
+
+-- CreateIndex
+CREATE INDEX "experiment_assignments_experimentId_variantId_idx" ON "experiment_assignments"("experimentId", "variantId");
+
+-- CreateIndex
+CREATE INDEX "experiment_assignments_subjectId_idx" ON "experiment_assignments"("subjectId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "experiment_assignments_experimentId_subjectId_key" ON "experiment_assignments"("experimentId", "subjectId");
+
+-- CreateIndex
+CREATE INDEX "experiment_events_experimentId_variantId_idx" ON "experiment_events"("experimentId", "variantId");
+
+-- CreateIndex
+CREATE INDEX "experiment_events_experimentId_eventType_idx" ON "experiment_events"("experimentId", "eventType");
+
+-- CreateIndex
+CREATE INDEX "experiment_events_subjectId_idx" ON "experiment_events"("subjectId");
+
+-- CreateIndex
+CREATE INDEX "model_drift_checks_modelVersionId_idx" ON "model_drift_checks"("modelVersionId");
+
+-- CreateIndex
+CREATE INDEX "model_drift_checks_driftDetected_idx" ON "model_drift_checks"("driftDetected");
+

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -103,3 +103,161 @@ model ApiUsage {
   @@index([apiKeyId, statusCode])
 }
 
+// ---------------------------------------------------------------------------
+// ML Model Registry & A/B Testing (MLOps)
+// ---------------------------------------------------------------------------
+
+model MLModel {
+  id          String        @id @default(cuid())
+  name        String        @unique
+  description String        @default("")
+  taskType    String        // e.g. "credit_scoring", "fraud_detection"
+  createdAt   DateTime      @default(now())
+  updatedAt   DateTime      @updatedAt
+
+  versions    MLModelVersion[]
+  experiments Experiment[]
+
+  @@map("ml_models")
+  @@index([taskType])
+}
+
+model MLModelVersion {
+  id                String    @id @default(cuid())
+  modelId           String
+  model             MLModel   @relation(fields: [modelId], references: [id], onDelete: Cascade)
+  version           String    // semantic version, e.g. "2.0.0"
+  stage             String    @default("staging") // staging | production | archived
+  artifactUri       String    // path/URI to .pkl / .joblib artifact
+  contentHash       String    // SHA256 of the model artifact (content-addressable)
+  frameworkVersion  String?   // e.g. scikit-learn==1.4.2
+  accuracy          Float?
+  precision         Float?
+  recall            Float?
+  f1Score           Float?
+  auc               Float?
+  trainingDataUri   String?
+  trainingDataHash  String?
+  hyperparameters   String    @default("{}") // JSON string
+  metadata          String    @default("{}") // JSON string
+  datasetVersion    String?
+  codeCommit        String?   // git commit SHA of training code
+  trainingRunId     String?   // link to external training run (e.g. MLflow run id)
+  approvedBy        String?
+  approvedAt        DateTime?
+  promotedAt        DateTime?
+  archivedAt        DateTime?
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @updatedAt
+
+  variants          ExperimentVariant[]
+  driftChecks       ModelDriftCheck[]
+
+  @@map("ml_model_versions")
+  @@unique([modelId, version])
+  @@index([modelId, stage])
+  @@index([contentHash])
+  @@index([stage])
+}
+
+model Experiment {
+  id                  String    @id @default(cuid())
+  key                 String    @unique
+  name                String
+  description         String    @default("")
+  modelId             String
+  model               MLModel   @relation(fields: [modelId], references: [id], onDelete: Cascade)
+  status              String    @default("draft") // draft | running | paused | completed | rolled_back
+  hypothesis          String    @default("")
+  metric              String    // primary conversion/success metric name
+  minimumDetectableEffect Float?
+  significanceLevel   Float     @default(0.05)
+  power               Float     @default(0.8)
+  bonferroniCorrection Boolean  @default(false)
+  canaryThresholdPct  Float     @default(5.0) // auto-rollback if degradation exceeds this %
+  canaryWindowHours   Int       @default(24)
+  startedAt           DateTime?
+  endedAt             DateTime?
+  createdAt           DateTime  @default(now())
+  updatedAt           DateTime  @updatedAt
+
+  variants            ExperimentVariant[]
+  assignments         ExperimentAssignment[]
+  events              ExperimentEvent[]
+
+  @@map("experiments")
+  @@index([modelId])
+  @@index([status])
+}
+
+model ExperimentVariant {
+  id            String     @id @default(cuid())
+  experimentId  String
+  experiment    Experiment @relation(fields: [experimentId], references: [id], onDelete: Cascade)
+  modelVersionId String
+  modelVersion  MLModelVersion @relation(fields: [modelVersionId], references: [id], onDelete: Cascade)
+  name          String     // e.g. "control", "treatment"
+  isControl     Boolean    @default(false)
+  trafficWeight Float      // 0-100, must sum to 100 across an experiment's variants
+  createdAt     DateTime   @default(now())
+  updatedAt     DateTime   @updatedAt
+
+  assignments   ExperimentAssignment[]
+  events        ExperimentEvent[]
+
+  @@map("experiment_variants")
+  @@unique([experimentId, name])
+  @@index([experimentId])
+}
+
+model ExperimentAssignment {
+  id            String     @id @default(cuid())
+  experimentId  String
+  experiment    Experiment @relation(fields: [experimentId], references: [id], onDelete: Cascade)
+  variantId     String
+  variant       ExperimentVariant @relation(fields: [variantId], references: [id], onDelete: Cascade)
+  subjectId     String     // user id, session id, or account id used for stickiness
+  assignedAt    DateTime   @default(now())
+
+  @@map("experiment_assignments")
+  @@unique([experimentId, subjectId])
+  @@index([experimentId, variantId])
+  @@index([subjectId])
+}
+
+model ExperimentEvent {
+  id            String     @id @default(cuid())
+  experimentId  String
+  experiment    Experiment @relation(fields: [experimentId], references: [id], onDelete: Cascade)
+  variantId     String
+  variant       ExperimentVariant @relation(fields: [variantId], references: [id], onDelete: Cascade)
+  subjectId     String
+  eventType     String     // "exposure" | "conversion" | "metric"
+  metricName    String?
+  metricValue   Float?
+  createdAt     DateTime   @default(now())
+
+  @@map("experiment_events")
+  @@index([experimentId, variantId])
+  @@index([experimentId, eventType])
+  @@index([subjectId])
+}
+
+model ModelDriftCheck {
+  id              String   @id @default(cuid())
+  modelVersionId  String
+  modelVersion    MLModelVersion @relation(fields: [modelVersionId], references: [id], onDelete: Cascade)
+  windowStart     DateTime
+  windowEnd       DateTime
+  baselineAuc     Float
+  observedAuc     Float
+  aucDrop         Float    // percentage drop relative to baseline
+  driftDetected   Boolean  @default(false)
+  alertSent       Boolean  @default(false)
+  createdAt       DateTime @default(now())
+
+  @@map("model_drift_checks")
+  @@index([modelVersionId])
+  @@index([driftDetected])
+}
+

--- a/backend/src/models/Experiment.ts
+++ b/backend/src/models/Experiment.ts
@@ -1,0 +1,150 @@
+import {
+  Experiment as PrismaExperiment,
+  ExperimentVariant as PrismaExperimentVariant,
+  ExperimentAssignment as PrismaExperimentAssignment,
+  ExperimentEvent as PrismaExperimentEvent,
+} from '@prisma/client';
+
+export type ExperimentStatus = 'draft' | 'running' | 'paused' | 'completed' | 'rolled_back';
+export type ExperimentEventType = 'exposure' | 'conversion' | 'metric';
+
+export interface ExperimentVariantInput {
+  name: string;
+  modelVersionId: string;
+  trafficWeight: number;
+  isControl?: boolean;
+}
+
+export interface ExperimentCreateInput {
+  key: string;
+  name: string;
+  description?: string;
+  modelId: string;
+  hypothesis?: string;
+  metric: string;
+  minimumDetectableEffect?: number;
+  significanceLevel?: number;
+  power?: number;
+  bonferroniCorrection?: boolean;
+  canaryThresholdPct?: number;
+  canaryWindowHours?: number;
+  variants: ExperimentVariantInput[];
+}
+
+export class Experiment {
+  constructor(
+    public id: string,
+    public key: string,
+    public name: string,
+    public description: string,
+    public modelId: string,
+    public status: ExperimentStatus,
+    public hypothesis: string,
+    public metric: string,
+    public minimumDetectableEffect: number | null,
+    public significanceLevel: number,
+    public power: number,
+    public bonferroniCorrection: boolean,
+    public canaryThresholdPct: number,
+    public canaryWindowHours: number,
+    public startedAt: Date | null,
+    public endedAt: Date | null,
+    public createdAt: Date,
+    public updatedAt: Date
+  ) {}
+
+  static fromPrisma(prismaExperiment: PrismaExperiment): Experiment {
+    return new Experiment(
+      prismaExperiment.id,
+      prismaExperiment.key,
+      prismaExperiment.name,
+      prismaExperiment.description,
+      prismaExperiment.modelId,
+      prismaExperiment.status as ExperimentStatus,
+      prismaExperiment.hypothesis,
+      prismaExperiment.metric,
+      prismaExperiment.minimumDetectableEffect,
+      prismaExperiment.significanceLevel,
+      prismaExperiment.power,
+      prismaExperiment.bonferroniCorrection,
+      prismaExperiment.canaryThresholdPct,
+      prismaExperiment.canaryWindowHours,
+      prismaExperiment.startedAt,
+      prismaExperiment.endedAt,
+      prismaExperiment.createdAt,
+      prismaExperiment.updatedAt
+    );
+  }
+}
+
+export class ExperimentVariant {
+  constructor(
+    public id: string,
+    public experimentId: string,
+    public modelVersionId: string,
+    public name: string,
+    public isControl: boolean,
+    public trafficWeight: number,
+    public createdAt: Date,
+    public updatedAt: Date
+  ) {}
+
+  static fromPrisma(prismaVariant: PrismaExperimentVariant): ExperimentVariant {
+    return new ExperimentVariant(
+      prismaVariant.id,
+      prismaVariant.experimentId,
+      prismaVariant.modelVersionId,
+      prismaVariant.name,
+      prismaVariant.isControl,
+      prismaVariant.trafficWeight,
+      prismaVariant.createdAt,
+      prismaVariant.updatedAt
+    );
+  }
+}
+
+export class ExperimentAssignment {
+  constructor(
+    public id: string,
+    public experimentId: string,
+    public variantId: string,
+    public subjectId: string,
+    public assignedAt: Date
+  ) {}
+
+  static fromPrisma(prismaAssignment: PrismaExperimentAssignment): ExperimentAssignment {
+    return new ExperimentAssignment(
+      prismaAssignment.id,
+      prismaAssignment.experimentId,
+      prismaAssignment.variantId,
+      prismaAssignment.subjectId,
+      prismaAssignment.assignedAt
+    );
+  }
+}
+
+export class ExperimentEvent {
+  constructor(
+    public id: string,
+    public experimentId: string,
+    public variantId: string,
+    public subjectId: string,
+    public eventType: ExperimentEventType,
+    public metricName: string | null,
+    public metricValue: number | null,
+    public createdAt: Date
+  ) {}
+
+  static fromPrisma(prismaEvent: PrismaExperimentEvent): ExperimentEvent {
+    return new ExperimentEvent(
+      prismaEvent.id,
+      prismaEvent.experimentId,
+      prismaEvent.variantId,
+      prismaEvent.subjectId,
+      prismaEvent.eventType as ExperimentEventType,
+      prismaEvent.metricName,
+      prismaEvent.metricValue,
+      prismaEvent.createdAt
+    );
+  }
+}

--- a/backend/src/models/MLModel.ts
+++ b/backend/src/models/MLModel.ts
@@ -1,0 +1,114 @@
+import {
+  MLModel as PrismaMLModel,
+  MLModelVersion as PrismaMLModelVersion,
+} from '@prisma/client';
+
+export type ModelStage = 'staging' | 'production' | 'archived';
+
+export interface MLModelCreateInput {
+  name: string;
+  description?: string;
+  taskType: string;
+}
+
+export interface ModelVersionRegisterInput {
+  modelId: string;
+  version: string;
+  artifactUri: string;
+  contentHash?: string; // computed by ModelRegistryService if omitted
+  frameworkVersion?: string;
+  accuracy?: number;
+  precision?: number;
+  recall?: number;
+  f1Score?: number;
+  auc?: number;
+  trainingDataUri?: string;
+  trainingDataHash?: string;
+  hyperparameters?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+  datasetVersion?: string;
+  codeCommit?: string;
+  trainingRunId?: string;
+}
+
+export class MLModel {
+  constructor(
+    public id: string,
+    public name: string,
+    public description: string,
+    public taskType: string,
+    public createdAt: Date,
+    public updatedAt: Date
+  ) {}
+
+  static fromPrisma(prismaModel: PrismaMLModel): MLModel {
+    return new MLModel(
+      prismaModel.id,
+      prismaModel.name,
+      prismaModel.description,
+      prismaModel.taskType,
+      prismaModel.createdAt,
+      prismaModel.updatedAt
+    );
+  }
+}
+
+export class MLModelVersion {
+  constructor(
+    public id: string,
+    public modelId: string,
+    public version: string,
+    public stage: ModelStage,
+    public artifactUri: string,
+    public contentHash: string,
+    public frameworkVersion: string | null,
+    public accuracy: number | null,
+    public precision: number | null,
+    public recall: number | null,
+    public f1Score: number | null,
+    public auc: number | null,
+    public trainingDataUri: string | null,
+    public trainingDataHash: string | null,
+    public hyperparameters: Record<string, unknown>,
+    public metadata: Record<string, unknown>,
+    public datasetVersion: string | null,
+    public codeCommit: string | null,
+    public trainingRunId: string | null,
+    public approvedBy: string | null,
+    public approvedAt: Date | null,
+    public promotedAt: Date | null,
+    public archivedAt: Date | null,
+    public createdAt: Date,
+    public updatedAt: Date
+  ) {}
+
+  static fromPrisma(prismaVersion: PrismaMLModelVersion): MLModelVersion {
+    return new MLModelVersion(
+      prismaVersion.id,
+      prismaVersion.modelId,
+      prismaVersion.version,
+      prismaVersion.stage as ModelStage,
+      prismaVersion.artifactUri,
+      prismaVersion.contentHash,
+      prismaVersion.frameworkVersion,
+      prismaVersion.accuracy,
+      prismaVersion.precision,
+      prismaVersion.recall,
+      prismaVersion.f1Score,
+      prismaVersion.auc,
+      prismaVersion.trainingDataUri,
+      prismaVersion.trainingDataHash,
+      JSON.parse(prismaVersion.hyperparameters || '{}'),
+      JSON.parse(prismaVersion.metadata || '{}'),
+      prismaVersion.datasetVersion,
+      prismaVersion.codeCommit,
+      prismaVersion.trainingRunId,
+      prismaVersion.approvedBy,
+      prismaVersion.approvedAt,
+      prismaVersion.promotedAt,
+      prismaVersion.archivedAt,
+      prismaVersion.createdAt,
+      prismaVersion.updatedAt
+    );
+  }
+}

--- a/backend/src/routes/mlModels.ts
+++ b/backend/src/routes/mlModels.ts
@@ -1,0 +1,227 @@
+import { Router, Request, Response } from 'express';
+import type { Router as ExpressRouter } from 'express';
+import { PrismaClient } from '@prisma/client';
+import { ModelRegistryService } from '../services/modelRegistryService';
+import { ExperimentService } from '../services/experimentService';
+import { ModelDriftDetector } from '../services/modelDriftDetector';
+import { validate } from '../middleware/validation';
+import { asyncHandler } from '../middleware/errorHandler';
+import {
+  registerModelBodySchema,
+  modelIdParamsSchema,
+  registerVersionBodySchema,
+  versionIdParamsSchema,
+  promoteVersionBodySchema,
+  rollbackBodySchema,
+  createExperimentBodySchema,
+  experimentIdParamsSchema,
+  assignVariantBodySchema,
+  trackConversionBodySchema,
+  recordDriftCheckBodySchema,
+} from '../schemas';
+
+/**
+ * ML model registry, A/B experiment and drift-detection routes.
+ *
+ * Mounted at /api/ml-models. A dedicated PrismaClient is accepted so routes
+ * can share the app-wide client instance in production while tests can
+ * inject an isolated one.
+ */
+export function createMLModelRouter(prisma: PrismaClient): Router {
+  const router = Router();
+  const registryService = new ModelRegistryService(prisma);
+  const experimentService = new ExperimentService(prisma);
+  const driftDetector = new ModelDriftDetector(prisma, registryService);
+
+  // -- Model registry ---------------------------------------------------
+
+  router.post(
+    '/',
+    validate({ body: registerModelBodySchema }),
+    asyncHandler(async (req: Request, res: Response) => {
+      const model = await registryService.registerModel(req.body);
+      res.status(201).json({ success: true, data: model });
+    })
+  );
+
+  router.get(
+    '/',
+    asyncHandler(async (_req: Request, res: Response) => {
+      const models = await registryService.listModels();
+      res.json({ success: true, data: models });
+    })
+  );
+
+  router.post(
+    '/:modelId/versions',
+    validate({ params: modelIdParamsSchema, body: registerVersionBodySchema }),
+    asyncHandler(async (req: Request, res: Response) => {
+      const version = await registryService.register({
+        modelId: req.params.modelId,
+        ...req.body,
+      });
+      res.status(201).json({ success: true, data: version });
+    })
+  );
+
+  router.get(
+    '/:modelId/versions',
+    validate({ params: modelIdParamsSchema }),
+    asyncHandler(async (req: Request, res: Response) => {
+      const stage = req.query.stage as 'staging' | 'production' | 'archived' | undefined;
+      const versions = await registryService.listVersions(req.params.modelId, stage);
+      res.json({ success: true, data: versions });
+    })
+  );
+
+  router.get(
+    '/:modelId/versions/production',
+    validate({ params: modelIdParamsSchema }),
+    asyncHandler(async (req: Request, res: Response) => {
+      const version = await registryService.getProductionVersion(req.params.modelId);
+      res.json({ success: true, data: version });
+    })
+  );
+
+  router.post(
+    '/versions/:versionId/promote',
+    validate({ params: versionIdParamsSchema, body: promoteVersionBodySchema }),
+    asyncHandler(async (req: Request, res: Response) => {
+      const version = await registryService.promote(req.params.versionId, req.body.approvedBy);
+      res.json({ success: true, data: version });
+    })
+  );
+
+  router.post(
+    '/:modelId/rollback',
+    validate({ params: modelIdParamsSchema, body: rollbackBodySchema }),
+    asyncHandler(async (req: Request, res: Response) => {
+      const version = await registryService.rollback(
+        req.params.modelId,
+        req.body.targetVersionId,
+        req.body.actor
+      );
+      res.json({ success: true, data: version });
+    })
+  );
+
+  // -- Drift detection ----------------------------------------------------
+
+  router.post(
+    '/versions/:versionId/drift-checks',
+    validate({ params: versionIdParamsSchema, body: recordDriftCheckBodySchema }),
+    asyncHandler(async (req: Request, res: Response) => {
+      const { windowStart, windowEnd, baselineAuc, observedAuc, alertThresholdPct, canaryThresholdPct, autoRollbackActor } =
+        req.body;
+      const result = await driftDetector.recordCheck(
+        {
+          modelVersionId: req.params.versionId,
+          windowStart: new Date(windowStart),
+          windowEnd: new Date(windowEnd),
+          baselineAuc,
+          observedAuc,
+        },
+        { alertThresholdPct, canaryThresholdPct, autoRollbackActor }
+      );
+      res.status(201).json({ success: true, data: result });
+    })
+  );
+
+  router.get(
+    '/versions/:versionId/drift-checks',
+    validate({ params: versionIdParamsSchema }),
+    asyncHandler(async (req: Request, res: Response) => {
+      const history = await driftDetector.getDriftHistory(req.params.versionId);
+      res.json({ success: true, data: history });
+    })
+  );
+
+  // -- Experiments ----------------------------------------------------------
+
+  router.post(
+    '/experiments',
+    validate({ body: createExperimentBodySchema }),
+    asyncHandler(async (req: Request, res: Response) => {
+      const experiment = await experimentService.createExperiment(req.body);
+      res.status(201).json({ success: true, data: experiment });
+    })
+  );
+
+  router.get(
+    '/experiments',
+    asyncHandler(async (_req: Request, res: Response) => {
+      const experiments = await experimentService.listExperiments();
+      res.json({ success: true, data: experiments });
+    })
+  );
+
+  router.get(
+    '/experiments/:experimentId',
+    validate({ params: experimentIdParamsSchema }),
+    asyncHandler(async (req: Request, res: Response) => {
+      const experiment = await experimentService.getExperiment(req.params.experimentId);
+      const variants = await experimentService.getVariants(req.params.experimentId);
+      res.json({ success: true, data: { ...experiment, variants } });
+    })
+  );
+
+  router.post(
+    '/experiments/:experimentId/start',
+    validate({ params: experimentIdParamsSchema }),
+    asyncHandler(async (req: Request, res: Response) => {
+      const experiment = await experimentService.startExperiment(req.params.experimentId);
+      res.json({ success: true, data: experiment });
+    })
+  );
+
+  router.post(
+    '/experiments/:experimentId/pause',
+    validate({ params: experimentIdParamsSchema }),
+    asyncHandler(async (req: Request, res: Response) => {
+      const experiment = await experimentService.pauseExperiment(req.params.experimentId);
+      res.json({ success: true, data: experiment });
+    })
+  );
+
+  router.post(
+    '/experiments/:experimentId/complete',
+    validate({ params: experimentIdParamsSchema }),
+    asyncHandler(async (req: Request, res: Response) => {
+      const experiment = await experimentService.completeExperiment(req.params.experimentId);
+      res.json({ success: true, data: experiment });
+    })
+  );
+
+  router.post(
+    '/experiments/:experimentId/assign',
+    validate({ params: experimentIdParamsSchema, body: assignVariantBodySchema }),
+    asyncHandler(async (req: Request, res: Response) => {
+      const variant = await experimentService.assignVariant(req.params.experimentId, req.body.subjectId);
+      res.json({ success: true, data: variant });
+    })
+  );
+
+  router.post(
+    '/experiments/:experimentId/convert',
+    validate({ params: experimentIdParamsSchema, body: trackConversionBodySchema }),
+    asyncHandler(async (req: Request, res: Response) => {
+      await experimentService.trackConversion(
+        req.params.experimentId,
+        req.body.subjectId,
+        req.body.metricValue
+      );
+      res.status(204).send();
+    })
+  );
+
+  router.get(
+    '/experiments/:experimentId/results',
+    validate({ params: experimentIdParamsSchema }),
+    asyncHandler(async (req: Request, res: Response) => {
+      const results = await experimentService.getResults(req.params.experimentId);
+      res.json({ success: true, data: results });
+    })
+  );
+
+  return router;
+}

--- a/backend/src/routes/v2/index.ts
+++ b/backend/src/routes/v2/index.ts
@@ -11,15 +11,18 @@ import type { Router as ExpressRouter } from 'express';
 import accountRoutes from '../accounts';
 import authRoutes from '../auth';
 import { createFeatureFlagRouter } from '../featureFlags';
+import { createMLModelRouter } from '../mlModels';
 import { generateCreditScore, generateFraudResult, toCreditScoreV2, toFraudResultV2 } from '../shared/scoring';
 import { validate } from '../../middleware/validation';
 import { creditScoreQuerySchema, fraudDetectionQuerySchema } from '../../schemas';
+import { prisma } from '../../prisma/client';
 
 const router: ExpressRouter = Router();
 
 router.use('/accounts', accountRoutes);
 router.use('/auth', authRoutes);
 router.use('/feature-flags', createFeatureFlagRouter());
+router.use('/ml-models', createMLModelRouter(prisma));
 
 // GET /credit-score - nested v2 contract
 router.get(

--- a/backend/src/schemas/index.ts
+++ b/backend/src/schemas/index.ts
@@ -10,3 +10,4 @@ export * from './auth.schema';
 export * from './featureFlag.schema';
 export * from './analytics.schema';
 export * from './creditScore.schema';
+export * from './mlModel.schema';

--- a/backend/src/schemas/mlModel.schema.ts
+++ b/backend/src/schemas/mlModel.schema.ts
@@ -1,0 +1,111 @@
+/**
+ * ML model registry & A/B experiment validation schemas.
+ */
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Model registry
+// ---------------------------------------------------------------------------
+
+export const registerModelBodySchema = z.object({
+  name: z.string().min(1, 'Model name is required').max(150),
+  description: z.string().max(2000).optional(),
+  taskType: z.string().min(1, 'taskType is required').max(100),
+});
+
+export const modelIdParamsSchema = z.object({
+  modelId: z.string().min(1, 'modelId is required'),
+});
+
+export const registerVersionBodySchema = z.object({
+  version: z.string().min(1, 'version is required').max(50),
+  artifactUri: z.string().min(1, 'artifactUri is required'),
+  contentHash: z
+    .string()
+    .regex(/^[a-f0-9]{64}$/i, 'contentHash must be a SHA256 hex digest')
+    .optional(),
+  frameworkVersion: z.string().max(100).optional(),
+  accuracy: z.number().min(0).max(1).optional(),
+  precision: z.number().min(0).max(1).optional(),
+  recall: z.number().min(0).max(1).optional(),
+  f1Score: z.number().min(0).max(1).optional(),
+  auc: z.number().min(0).max(1).optional(),
+  trainingDataUri: z.string().optional(),
+  trainingDataHash: z.string().optional(),
+  hyperparameters: z.record(z.unknown()).optional(),
+  metadata: z.record(z.unknown()).optional(),
+  datasetVersion: z.string().max(100).optional(),
+  codeCommit: z.string().max(64).optional(),
+  trainingRunId: z.string().max(150).optional(),
+});
+
+export const versionIdParamsSchema = z.object({
+  versionId: z.string().min(1, 'versionId is required'),
+});
+
+export const promoteVersionBodySchema = z.object({
+  approvedBy: z.string().min(1, 'approvedBy is required for the promotion approval gate'),
+});
+
+export const rollbackBodySchema = z.object({
+  targetVersionId: z.string().min(1, 'targetVersionId is required'),
+  actor: z.string().min(1, 'actor is required'),
+});
+
+// ---------------------------------------------------------------------------
+// Experiments
+// ---------------------------------------------------------------------------
+
+export const experimentVariantSchema = z.object({
+  name: z.string().min(1).max(100),
+  modelVersionId: z.string().min(1),
+  trafficWeight: z.number().min(0).max(100),
+  isControl: z.boolean().optional(),
+});
+
+export const createExperimentBodySchema = z.object({
+  key: z
+    .string()
+    .min(1, 'key is required')
+    .max(100)
+    .regex(/^[a-z0-9-_]+$/i, 'key must be alphanumeric with dashes/underscores'),
+  name: z.string().min(1).max(150),
+  description: z.string().max(2000).optional(),
+  modelId: z.string().min(1, 'modelId is required'),
+  hypothesis: z.string().max(2000).optional(),
+  metric: z.string().min(1, 'metric is required').max(100),
+  minimumDetectableEffect: z.number().positive().optional(),
+  significanceLevel: z.number().min(0.001).max(0.5).optional(),
+  power: z.number().min(0.5).max(0.999).optional(),
+  bonferroniCorrection: z.boolean().optional(),
+  canaryThresholdPct: z.number().min(0).max(100).optional(),
+  canaryWindowHours: z.number().int().min(1).max(720).optional(),
+  variants: z.array(experimentVariantSchema).min(2, 'At least two variants are required'),
+});
+
+export const experimentIdParamsSchema = z.object({
+  experimentId: z.string().min(1, 'experimentId is required'),
+});
+
+export const assignVariantBodySchema = z.object({
+  subjectId: z.string().min(1, 'subjectId is required'),
+});
+
+export const trackConversionBodySchema = z.object({
+  subjectId: z.string().min(1, 'subjectId is required'),
+  metricValue: z.number().optional(),
+});
+
+// ---------------------------------------------------------------------------
+// Drift detection
+// ---------------------------------------------------------------------------
+
+export const recordDriftCheckBodySchema = z.object({
+  windowStart: z.string().refine((val) => !isNaN(Date.parse(val)), 'Invalid windowStart date'),
+  windowEnd: z.string().refine((val) => !isNaN(Date.parse(val)), 'Invalid windowEnd date'),
+  baselineAuc: z.number().min(0).max(1),
+  observedAuc: z.number().min(0).max(1),
+  alertThresholdPct: z.number().min(0).max(100).optional(),
+  canaryThresholdPct: z.number().min(0).max(100).optional(),
+  autoRollbackActor: z.string().optional(),
+});

--- a/backend/src/services/experimentService.ts
+++ b/backend/src/services/experimentService.ts
@@ -1,0 +1,326 @@
+import { PrismaClient } from '@prisma/client';
+import { createHash } from 'crypto';
+import {
+  Experiment,
+  ExperimentVariant,
+  ExperimentAssignment,
+  ExperimentCreateInput,
+} from '../models/Experiment';
+import {
+  checkSignificance,
+  bonferroniCorrectedAlpha,
+  calculateMinimumSampleSize,
+  VariantSample,
+  SignificanceResult,
+  PowerAnalysisResult,
+} from '../utils/abStatistics';
+import { log } from '../utils/logger';
+import { ConflictError, NotFoundError, ValidationError } from '../utils/errors';
+
+export interface VariantResult {
+  variant: ExperimentVariant;
+  exposures: number;
+  conversions: number;
+  conversionRate: number;
+  significance?: SignificanceResult;
+}
+
+export interface ExperimentResults {
+  experiment: Experiment;
+  control: VariantResult;
+  treatments: VariantResult[];
+  powerAnalysis: PowerAnalysisResult | null;
+  readyForDecision: boolean;
+}
+
+const TRAFFIC_WEIGHT_TOLERANCE = 0.001;
+
+/**
+ * A/B testing service: experiment creation with configurable traffic
+ * splitting, deterministic sticky variant assignment, conversion tracking
+ * and statistical-significance analysis (with peek prevention and
+ * Bonferroni correction for multi-variant experiments).
+ */
+export class ExperimentService {
+  constructor(private prisma: PrismaClient) {}
+
+  async createExperiment(input: ExperimentCreateInput): Promise<Experiment> {
+    if (input.variants.length < 2) {
+      throw new ValidationError('An experiment requires at least two variants (control + treatment)');
+    }
+
+    const totalWeight = input.variants.reduce((sum, v) => sum + v.trafficWeight, 0);
+    if (Math.abs(totalWeight - 100) > TRAFFIC_WEIGHT_TOLERANCE) {
+      throw new ValidationError(`Variant traffic weights must sum to 100 (got ${totalWeight})`);
+    }
+
+    const controlCount = input.variants.filter((v) => v.isControl).length;
+    if (controlCount > 1) {
+      throw new ValidationError('An experiment can have at most one control variant');
+    }
+
+    const existing = await this.prisma.experiment.findUnique({ where: { key: input.key } });
+    if (existing) {
+      throw new ConflictError(`Experiment with key '${input.key}' already exists`);
+    }
+
+    const prismaExperiment = await this.prisma.experiment.create({
+      data: {
+        key: input.key,
+        name: input.name,
+        description: input.description || '',
+        modelId: input.modelId,
+        hypothesis: input.hypothesis || '',
+        metric: input.metric,
+        minimumDetectableEffect: input.minimumDetectableEffect,
+        significanceLevel: input.significanceLevel ?? 0.05,
+        power: input.power ?? 0.8,
+        bonferroniCorrection: input.bonferroniCorrection ?? input.variants.length > 2,
+        canaryThresholdPct: input.canaryThresholdPct ?? 5.0,
+        canaryWindowHours: input.canaryWindowHours ?? 24,
+        variants: {
+          create: input.variants.map((v, index) => ({
+            name: v.name,
+            modelVersionId: v.modelVersionId,
+            trafficWeight: v.trafficWeight,
+            isControl: v.isControl ?? index === 0,
+          })),
+        },
+      },
+    });
+
+    log.info('Experiment created', {
+      experimentId: prismaExperiment.id,
+      key: prismaExperiment.key,
+      variantCount: input.variants.length,
+    });
+
+    return Experiment.fromPrisma(prismaExperiment);
+  }
+
+  async startExperiment(experimentId: string): Promise<Experiment> {
+    const prismaExperiment = await this.prisma.experiment.update({
+      where: { id: experimentId },
+      data: { status: 'running', startedAt: new Date() },
+    });
+    return Experiment.fromPrisma(prismaExperiment);
+  }
+
+  async pauseExperiment(experimentId: string): Promise<Experiment> {
+    const prismaExperiment = await this.prisma.experiment.update({
+      where: { id: experimentId },
+      data: { status: 'paused' },
+    });
+    return Experiment.fromPrisma(prismaExperiment);
+  }
+
+  async completeExperiment(experimentId: string): Promise<Experiment> {
+    const prismaExperiment = await this.prisma.experiment.update({
+      where: { id: experimentId },
+      data: { status: 'completed', endedAt: new Date() },
+    });
+    return Experiment.fromPrisma(prismaExperiment);
+  }
+
+  async getExperiment(experimentId: string): Promise<Experiment> {
+    const prismaExperiment = await this.prisma.experiment.findUnique({ where: { id: experimentId } });
+    if (!prismaExperiment) {
+      throw new NotFoundError(`Experiment '${experimentId}' not found`);
+    }
+    return Experiment.fromPrisma(prismaExperiment);
+  }
+
+  async listExperiments(): Promise<Experiment[]> {
+    const prismaExperiments = await this.prisma.experiment.findMany({ orderBy: { createdAt: 'desc' } });
+    return prismaExperiments.map(Experiment.fromPrisma);
+  }
+
+  async getVariants(experimentId: string): Promise<ExperimentVariant[]> {
+    const prismaVariants = await this.prisma.experimentVariant.findMany({
+      where: { experimentId },
+      orderBy: { createdAt: 'asc' },
+    });
+    return prismaVariants.map(ExperimentVariant.fromPrisma);
+  }
+
+  /**
+   * Deterministically buckets a subject into [0, 100) using a hash of the
+   * experiment key and subject id. This ensures stable assignment (the same
+   * subject always gets the same bucket for a given experiment) even across
+   * multiple app servers / network partitions, without needing shared state
+   * beyond the persisted assignment record.
+   */
+  private hashToBucket(experimentKey: string, subjectId: string): number {
+    const hash = createHash('sha256').update(`${experimentKey}:${subjectId}`).digest('hex');
+    const intValue = parseInt(hash.slice(0, 8), 16);
+    return (intValue / 0xffffffff) * 100;
+  }
+
+  /**
+   * Assigns a subject (user/session/account id) to a variant, honoring
+   * configured traffic weights. Assignment is sticky: once a subject is
+   * assigned, the same variant is always returned for that experiment.
+   */
+  async assignVariant(experimentId: string, subjectId: string): Promise<ExperimentVariant> {
+    const existingAssignment = await this.prisma.experimentAssignment.findUnique({
+      where: { experimentId_subjectId: { experimentId, subjectId } },
+      include: { variant: true },
+    });
+
+    if (existingAssignment) {
+      return ExperimentVariant.fromPrisma(existingAssignment.variant);
+    }
+
+    const experiment = await this.getExperiment(experimentId);
+    const variants = await this.getVariants(experimentId);
+    if (variants.length === 0) {
+      throw new ValidationError('Experiment has no variants configured');
+    }
+
+    const bucket = this.hashToBucket(experiment.key, subjectId);
+    let cumulative = 0;
+    let selected = variants[variants.length - 1];
+    for (const variant of variants) {
+      cumulative += variant.trafficWeight;
+      if (bucket < cumulative) {
+        selected = variant;
+        break;
+      }
+    }
+
+    try {
+      await this.prisma.experimentAssignment.create({
+        data: { experimentId, variantId: selected.id, subjectId },
+      });
+    } catch (err) {
+      // Race: another request assigned this subject concurrently. Return the
+      // now-persisted assignment rather than failing the request.
+      const raced = await this.prisma.experimentAssignment.findUnique({
+        where: { experimentId_subjectId: { experimentId, subjectId } },
+        include: { variant: true },
+      });
+      if (raced) return ExperimentVariant.fromPrisma(raced.variant);
+      throw err;
+    }
+
+    await this.prisma.experimentEvent.create({
+      data: { experimentId, variantId: selected.id, subjectId, eventType: 'exposure' },
+    });
+
+    return selected;
+  }
+
+  async getAssignment(experimentId: string, subjectId: string): Promise<ExperimentAssignment | null> {
+    const prismaAssignment = await this.prisma.experimentAssignment.findUnique({
+      where: { experimentId_subjectId: { experimentId, subjectId } },
+    });
+    return prismaAssignment ? ExperimentAssignment.fromPrisma(prismaAssignment) : null;
+  }
+
+  /**
+   * Records a conversion event for the subject's assigned variant. If the
+   * metric has a numeric value (e.g. loss amount avoided, score delta) it
+   * can be attached via `metricValue`.
+   */
+  async trackConversion(experimentId: string, subjectId: string, metricValue?: number): Promise<void> {
+    const assignment = await this.getAssignment(experimentId, subjectId);
+    if (!assignment) {
+      throw new ValidationError('Subject has not been assigned a variant for this experiment');
+    }
+
+    const experiment = await this.getExperiment(experimentId);
+
+    await this.prisma.experimentEvent.create({
+      data: {
+        experimentId,
+        variantId: assignment.variantId,
+        subjectId,
+        eventType: 'conversion',
+        metricName: experiment.metric,
+        metricValue,
+      },
+    });
+  }
+
+  private async getVariantSample(experimentId: string, variantId: string): Promise<VariantSample> {
+    const [exposures, conversions] = await Promise.all([
+      this.prisma.experimentEvent.count({
+        where: { experimentId, variantId, eventType: 'exposure' },
+      }),
+      this.prisma.experimentEvent.count({
+        where: { experimentId, variantId, eventType: 'conversion' },
+      }),
+    ]);
+
+    const variant = await this.prisma.experimentVariant.findUniqueOrThrow({ where: { id: variantId } });
+
+    return { name: variant.name, exposures, conversions };
+  }
+
+  /**
+   * Computes full statistical results for an experiment: per-variant
+   * conversion rates, significance vs. control (two-proportion z-test,
+   * Bonferroni-corrected when there are more than two variants), and
+   * whether the experiment has collected the minimum sample size required
+   * by its configured power analysis (peek prevention).
+   */
+  async getResults(experimentId: string): Promise<ExperimentResults> {
+    const experiment = await this.getExperiment(experimentId);
+    const variants = await this.getVariants(experimentId);
+
+    const controlVariant = variants.find((v) => v.isControl) || variants[0];
+    const treatmentVariants = variants.filter((v) => v.id !== controlVariant.id);
+
+    const controlSample = await this.getVariantSample(experimentId, controlVariant.id);
+
+    const alpha = experiment.bonferroniCorrection
+      ? bonferroniCorrectedAlpha(experiment.significanceLevel, treatmentVariants.length)
+      : experiment.significanceLevel;
+
+    const treatments: VariantResult[] = [];
+    for (const variant of treatmentVariants) {
+      const sample = await this.getVariantSample(experimentId, variant.id);
+      const significance =
+        controlSample.exposures > 0 && sample.exposures > 0
+          ? checkSignificance(controlSample, sample, alpha)
+          : undefined;
+
+      treatments.push({
+        variant,
+        exposures: sample.exposures,
+        conversions: sample.conversions,
+        conversionRate: sample.exposures > 0 ? sample.conversions / sample.exposures : 0,
+        significance,
+      });
+    }
+
+    let powerAnalysis: PowerAnalysisResult | null = null;
+    const baselineRate = controlSample.exposures > 0 ? controlSample.conversions / controlSample.exposures : 0;
+    if (experiment.minimumDetectableEffect && baselineRate > 0 && baselineRate < 1) {
+      powerAnalysis = calculateMinimumSampleSize(
+        baselineRate,
+        experiment.minimumDetectableEffect,
+        experiment.significanceLevel,
+        experiment.power
+      );
+    }
+
+    const readyForDecision = powerAnalysis
+      ? controlSample.exposures >= powerAnalysis.requiredSampleSizePerVariant &&
+        treatments.every((t) => t.exposures >= powerAnalysis!.requiredSampleSizePerVariant)
+      : false;
+
+    return {
+      experiment,
+      control: {
+        variant: controlVariant,
+        exposures: controlSample.exposures,
+        conversions: controlSample.conversions,
+        conversionRate: baselineRate,
+      },
+      treatments,
+      powerAnalysis,
+      readyForDecision,
+    };
+  }
+}

--- a/backend/src/services/modelDriftDetector.ts
+++ b/backend/src/services/modelDriftDetector.ts
@@ -1,0 +1,166 @@
+import { PrismaClient } from '@prisma/client';
+import { ModelRegistryService } from './modelRegistryService';
+import { log } from '../utils/logger';
+import { NotFoundError, ValidationError } from '../utils/errors';
+
+export interface DriftCheckInput {
+  modelVersionId: string;
+  windowStart: Date;
+  windowEnd: Date;
+  baselineAuc: number;
+  observedAuc: number;
+}
+
+export interface DriftCheckResult {
+  id: string;
+  modelVersionId: string;
+  baselineAuc: number;
+  observedAuc: number;
+  aucDropPct: number;
+  driftDetected: boolean;
+  rolledBack: boolean;
+}
+
+const DEFAULT_DRIFT_THRESHOLD_PCT = 3.0; // alert when AUC drops more than 3%
+const DEFAULT_CANARY_THRESHOLD_PCT = 5.0; // auto-rollback when degradation exceeds 5%
+
+/**
+ * Monitors production model performance for drift and runs automated canary
+ * analysis: if a production version's observed AUC degrades beyond the
+ * configured threshold relative to its baseline, it is flagged (and,
+ * for canary-severity degradation, automatically rolled back).
+ */
+export class ModelDriftDetector {
+  constructor(
+    private prisma: PrismaClient,
+    private registryService: ModelRegistryService
+  ) {}
+
+  /**
+   * Records a drift check for a monitoring window and returns whether drift
+   * was detected. Alerting threshold defaults to 3% AUC drop per the
+   * acceptance criteria; canary auto-rollback uses a separate (usually
+   * higher) threshold since rollback is a more disruptive action than an
+   * alert.
+   */
+  async recordCheck(
+    input: DriftCheckInput,
+    options: { alertThresholdPct?: number; canaryThresholdPct?: number; autoRollbackActor?: string } = {}
+  ): Promise<DriftCheckResult> {
+    if (input.baselineAuc <= 0) {
+      throw new ValidationError('baselineAuc must be > 0');
+    }
+
+    const alertThresholdPct = options.alertThresholdPct ?? DEFAULT_DRIFT_THRESHOLD_PCT;
+    const canaryThresholdPct = options.canaryThresholdPct ?? DEFAULT_CANARY_THRESHOLD_PCT;
+
+    const aucDropPct = ((input.baselineAuc - input.observedAuc) / input.baselineAuc) * 100;
+    const driftDetected = aucDropPct > alertThresholdPct;
+
+    const check = await this.prisma.modelDriftCheck.create({
+      data: {
+        modelVersionId: input.modelVersionId,
+        windowStart: input.windowStart,
+        windowEnd: input.windowEnd,
+        baselineAuc: input.baselineAuc,
+        observedAuc: input.observedAuc,
+        aucDrop: aucDropPct,
+        driftDetected,
+      },
+    });
+
+    if (driftDetected) {
+      log.warn('Model drift detected', {
+        modelVersionId: input.modelVersionId,
+        aucDropPct,
+        baselineAuc: input.baselineAuc,
+        observedAuc: input.observedAuc,
+      });
+    }
+
+    let rolledBack = false;
+    if (aucDropPct > canaryThresholdPct) {
+      rolledBack = await this.autoRollbackIfNeeded(input.modelVersionId, options.autoRollbackActor);
+    }
+
+    if (driftDetected || rolledBack) {
+      await this.prisma.modelDriftCheck.update({
+        where: { id: check.id },
+        data: { alertSent: true },
+      });
+    }
+
+    return {
+      id: check.id,
+      modelVersionId: input.modelVersionId,
+      baselineAuc: input.baselineAuc,
+      observedAuc: input.observedAuc,
+      aucDropPct,
+      driftDetected,
+      rolledBack,
+    };
+  }
+
+  /**
+   * Automated canary rollback: when a production version's degradation
+   * exceeds the canary threshold, roll back to the most recently archived
+   * (previously production) version for the same model.
+   */
+  private async autoRollbackIfNeeded(modelVersionId: string, actor?: string): Promise<boolean> {
+    const version = await this.prisma.mLModelVersion.findUnique({ where: { id: modelVersionId } });
+    if (!version || version.stage !== 'production') {
+      return false;
+    }
+
+    const previousVersion = await this.prisma.mLModelVersion.findFirst({
+      where: { modelId: version.modelId, stage: 'archived', id: { not: modelVersionId } },
+      orderBy: { archivedAt: 'desc' },
+    });
+
+    if (!previousVersion) {
+      log.error('Canary rollback triggered but no previous production version is available', undefined, {
+        modelVersionId,
+      });
+      return false;
+    }
+
+    await this.registryService.rollback(
+      version.modelId,
+      previousVersion.id,
+      actor || 'model-drift-detector'
+    );
+
+    log.warn('Automated canary rollback executed', {
+      modelId: version.modelId,
+      fromVersion: version.version,
+      toVersion: previousVersion.version,
+    });
+
+    return true;
+  }
+
+  async getDriftHistory(modelVersionId: string): Promise<DriftCheckResult[]> {
+    const checks = await this.prisma.modelDriftCheck.findMany({
+      where: { modelVersionId },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    return checks.map((c) => ({
+      id: c.id,
+      modelVersionId: c.modelVersionId,
+      baselineAuc: c.baselineAuc,
+      observedAuc: c.observedAuc,
+      aucDropPct: c.aucDrop,
+      driftDetected: c.driftDetected,
+      rolledBack: false,
+    }));
+  }
+
+  async getVersionOrThrow(modelVersionId: string) {
+    const version = await this.prisma.mLModelVersion.findUnique({ where: { id: modelVersionId } });
+    if (!version) {
+      throw new NotFoundError(`Model version '${modelVersionId}' not found`);
+    }
+    return version;
+  }
+}

--- a/backend/src/services/modelRegistryService.ts
+++ b/backend/src/services/modelRegistryService.ts
@@ -1,0 +1,217 @@
+import { PrismaClient } from '@prisma/client';
+import { createHash } from 'crypto';
+import {
+  MLModel,
+  MLModelVersion,
+  MLModelCreateInput,
+  ModelVersionRegisterInput,
+  ModelStage,
+} from '../models/MLModel';
+import { log } from '../utils/logger';
+import { ConflictError, NotFoundError, ValidationError } from '../utils/errors';
+
+/**
+ * Model registry: version control for ML model artifacts with
+ * content-addressable storage, staging -> production promotion gates,
+ * and lineage tracking (training run, dataset, code commit).
+ */
+export class ModelRegistryService {
+  constructor(private prisma: PrismaClient) {}
+
+  /**
+   * Computes the SHA256 content hash of a model artifact buffer. Used for
+   * content-addressable storage so identical artifacts are never duplicated
+   * and tampering/drift in the artifact is detectable.
+   */
+  static hashArtifact(artifact: Buffer | string): string {
+    return createHash('sha256').update(artifact).digest('hex');
+  }
+
+  async registerModel(input: MLModelCreateInput): Promise<MLModel> {
+    const existing = await this.prisma.mLModel.findUnique({ where: { name: input.name } });
+    if (existing) {
+      throw new ConflictError(`Model '${input.name}' is already registered`);
+    }
+
+    const prismaModel = await this.prisma.mLModel.create({
+      data: {
+        name: input.name,
+        description: input.description || '',
+        taskType: input.taskType,
+      },
+    });
+
+    log.info('ML model registered', { modelId: prismaModel.id, name: prismaModel.name });
+    return MLModel.fromPrisma(prismaModel);
+  }
+
+  async getModelByName(name: string): Promise<MLModel | null> {
+    const prismaModel = await this.prisma.mLModel.findUnique({ where: { name } });
+    return prismaModel ? MLModel.fromPrisma(prismaModel) : null;
+  }
+
+  async listModels(): Promise<MLModel[]> {
+    const prismaModels = await this.prisma.mLModel.findMany({ orderBy: { createdAt: 'desc' } });
+    return prismaModels.map(MLModel.fromPrisma);
+  }
+
+  /**
+   * Registers a new model version (artifact) under content-addressable
+   * storage. New versions always start in the `staging` stage and require
+   * an explicit `promote()` call (with an approval gate) to reach production.
+   */
+  async register(input: ModelVersionRegisterInput): Promise<MLModelVersion> {
+    const model = await this.prisma.mLModel.findUnique({ where: { id: input.modelId } });
+    if (!model) {
+      throw new NotFoundError(`Model '${input.modelId}' not found`);
+    }
+
+    const existingVersion = await this.prisma.mLModelVersion.findUnique({
+      where: { modelId_version: { modelId: input.modelId, version: input.version } },
+    });
+    if (existingVersion) {
+      throw new ConflictError(`Version '${input.version}' already exists for this model`);
+    }
+
+    const contentHash = input.contentHash || ModelRegistryService.hashArtifact(input.artifactUri);
+
+    const prismaVersion = await this.prisma.mLModelVersion.create({
+      data: {
+        modelId: input.modelId,
+        version: input.version,
+        stage: 'staging',
+        artifactUri: input.artifactUri,
+        contentHash,
+        frameworkVersion: input.frameworkVersion,
+        accuracy: input.accuracy,
+        precision: input.precision,
+        recall: input.recall,
+        f1Score: input.f1Score,
+        auc: input.auc,
+        trainingDataUri: input.trainingDataUri,
+        trainingDataHash: input.trainingDataHash,
+        hyperparameters: JSON.stringify(input.hyperparameters || {}),
+        metadata: JSON.stringify(input.metadata || {}),
+        datasetVersion: input.datasetVersion,
+        codeCommit: input.codeCommit,
+        trainingRunId: input.trainingRunId,
+      },
+    });
+
+    log.info('Model version registered', {
+      modelId: input.modelId,
+      version: input.version,
+      contentHash,
+    });
+
+    return MLModelVersion.fromPrisma(prismaVersion);
+  }
+
+  async getVersion(modelId: string, version: string): Promise<MLModelVersion> {
+    const prismaVersion = await this.prisma.mLModelVersion.findUnique({
+      where: { modelId_version: { modelId, version } },
+    });
+    if (!prismaVersion) {
+      throw new NotFoundError(`Version '${version}' not found for model '${modelId}'`);
+    }
+    return MLModelVersion.fromPrisma(prismaVersion);
+  }
+
+  async getVersionById(versionId: string): Promise<MLModelVersion> {
+    const prismaVersion = await this.prisma.mLModelVersion.findUnique({ where: { id: versionId } });
+    if (!prismaVersion) {
+      throw new NotFoundError(`Model version '${versionId}' not found`);
+    }
+    return MLModelVersion.fromPrisma(prismaVersion);
+  }
+
+  async listVersions(modelId: string, stage?: ModelStage): Promise<MLModelVersion[]> {
+    const prismaVersions = await this.prisma.mLModelVersion.findMany({
+      where: { modelId, ...(stage ? { stage } : {}) },
+      orderBy: { createdAt: 'desc' },
+    });
+    return prismaVersions.map(MLModelVersion.fromPrisma);
+  }
+
+  /**
+   * Promotes a staging model version to production, requiring an approval
+   * gate (an `approvedBy` actor identifier). Any currently-production
+   * version for the same model is archived.
+   */
+  async promote(versionId: string, approvedBy: string): Promise<MLModelVersion> {
+    if (!approvedBy) {
+      throw new ValidationError('promote() requires an approvedBy actor for the approval gate');
+    }
+
+    const version = await this.getVersionById(versionId);
+    if (version.stage === 'production') {
+      return version;
+    }
+
+    await this.prisma.$transaction(async (tx) => {
+      await tx.mLModelVersion.updateMany({
+        where: { modelId: version.modelId, stage: 'production' },
+        data: { stage: 'archived', archivedAt: new Date() },
+      });
+
+      await tx.mLModelVersion.update({
+        where: { id: versionId },
+        data: {
+          stage: 'production',
+          approvedBy,
+          approvedAt: new Date(),
+          promotedAt: new Date(),
+        },
+      });
+    });
+
+    log.info('Model version promoted to production', {
+      versionId,
+      modelId: version.modelId,
+      approvedBy,
+    });
+
+    return this.getVersionById(versionId);
+  }
+
+  /**
+   * Rolls back production to a previously known-good version. The current
+   * production version is archived and the target version is restored to
+   * production without requiring a new approval (rollback is itself the
+   * safety mechanism).
+   */
+  async rollback(modelId: string, targetVersionId: string, actor: string): Promise<MLModelVersion> {
+    const target = await this.getVersionById(targetVersionId);
+    if (target.modelId !== modelId) {
+      throw new ValidationError('Target version does not belong to the specified model');
+    }
+
+    await this.prisma.$transaction(async (tx) => {
+      await tx.mLModelVersion.updateMany({
+        where: { modelId, stage: 'production' },
+        data: { stage: 'archived', archivedAt: new Date() },
+      });
+
+      await tx.mLModelVersion.update({
+        where: { id: targetVersionId },
+        data: {
+          stage: 'production',
+          promotedAt: new Date(),
+          approvedBy: actor,
+          approvedAt: new Date(),
+        },
+      });
+    });
+
+    log.warn('Model rolled back', { modelId, targetVersionId, actor });
+
+    return this.getVersionById(targetVersionId);
+  }
+
+  async getProductionVersion(modelId: string): Promise<MLModelVersion | null> {
+    const prismaVersion = await this.prisma.mLModelVersion.findFirst({
+      where: { modelId, stage: 'production' },
+    });
+    return prismaVersion ? MLModelVersion.fromPrisma(prismaVersion) : null;
+  }
+}

--- a/backend/src/utils/abStatistics.ts
+++ b/backend/src/utils/abStatistics.ts
@@ -1,0 +1,231 @@
+/**
+ * Statistical helpers for A/B test analysis.
+ *
+ * Implements a two-proportion z-test, which is the standard approach for
+ * conversion-rate experiments (exposures -> conversions per variant).
+ */
+
+export interface VariantSample {
+  name: string;
+  exposures: number;
+  conversions: number;
+}
+
+export interface ConfidenceInterval {
+  lower: number;
+  upper: number;
+  confidenceLevel: number;
+}
+
+export interface SignificanceResult {
+  pValue: number;
+  zScore: number;
+  significant: boolean;
+  alpha: number;
+  controlRate: number;
+  variantRate: number;
+  relativeUplift: number;
+  confidenceInterval: ConfidenceInterval;
+}
+
+export interface PowerAnalysisResult {
+  requiredSampleSizePerVariant: number;
+  minimumDetectableEffect: number;
+  baselineRate: number;
+  power: number;
+  alpha: number;
+}
+
+// Standard normal CDF via Abramowitz & Stegun approximation (accurate to ~1e-7).
+function normalCdf(z: number): number {
+  const t = 1 / (1 + 0.2316419 * Math.abs(z));
+  const d = 0.3989423 * Math.exp((-z * z) / 2);
+  let prob =
+    d *
+    t *
+    (0.3193815 +
+      t * (-0.3565638 + t * (1.781478 + t * (-1.821256 + t * 1.330274))));
+  if (z > 0) prob = 1 - prob;
+  return prob;
+}
+
+// Inverse standard normal CDF (Beasley-Springer-Moro algorithm).
+export function inverseNormalCdf(p: number): number {
+  if (p <= 0 || p >= 1) {
+    throw new Error('p must be in the open interval (0, 1)');
+  }
+
+  const a = [
+    -3.969683028665376e1, 2.209460984245205e2, -2.759285104469687e2,
+    1.38357751867269e2, -3.066479806614716e1, 2.506628277459239,
+  ];
+  const b = [
+    -5.447609879822406e1, 1.615858368580409e2, -1.556989798598866e2,
+    6.680131188771972e1, -1.328068155288572e1,
+  ];
+  const c = [
+    -7.784894002430293e-3, -3.223964580411365e-1, -2.400758277161838,
+    -2.549732539343734, 4.374664141464968, 2.938163982698783,
+  ];
+  const d = [
+    7.784695709041462e-3, 3.224671290700398e-1, 2.445134137142996,
+    3.754408661907416,
+  ];
+
+  const pLow = 0.02425;
+  const pHigh = 1 - pLow;
+
+  let q: number, r: number;
+
+  if (p < pLow) {
+    q = Math.sqrt(-2 * Math.log(p));
+    return (
+      (((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]) /
+      ((((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1)
+    );
+  } else if (p <= pHigh) {
+    q = p - 0.5;
+    r = q * q;
+    return (
+      ((((((a[0] * r + a[1]) * r + a[2]) * r + a[3]) * r + a[4]) * r + a[5]) *
+        q) /
+      (((((b[0] * r + b[1]) * r + b[2]) * r + b[3]) * r + b[4]) * r + 1)
+    );
+  } else {
+    q = Math.sqrt(-2 * Math.log(1 - p));
+    return (
+      -(((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]) /
+      ((((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1)
+    );
+  }
+}
+
+/**
+ * Applies a Bonferroni correction to the significance level to control the
+ * family-wise error rate when comparing more than two variants.
+ */
+export function bonferroniCorrectedAlpha(alpha: number, numComparisons: number): number {
+  if (numComparisons < 1) {
+    throw new Error('numComparisons must be >= 1');
+  }
+  return alpha / numComparisons;
+}
+
+/**
+ * Two-proportion z-test comparing a control and a treatment variant.
+ */
+export function checkSignificance(
+  control: VariantSample,
+  variant: VariantSample,
+  alpha: number = 0.05
+): SignificanceResult {
+  if (control.exposures <= 0 || variant.exposures <= 0) {
+    throw new Error('Both variants must have at least one exposure');
+  }
+
+  const p1 = control.conversions / control.exposures;
+  const p2 = variant.conversions / variant.exposures;
+  const pooled =
+    (control.conversions + variant.conversions) /
+    (control.exposures + variant.exposures);
+
+  const se = Math.sqrt(
+    pooled * (1 - pooled) * (1 / control.exposures + 1 / variant.exposures)
+  );
+
+  const zScore = se === 0 ? 0 : (p2 - p1) / se;
+  const pValue = 2 * (1 - normalCdf(Math.abs(zScore)));
+
+  const relativeUplift = p1 === 0 ? 0 : (p2 - p1) / p1;
+
+  return {
+    pValue,
+    zScore,
+    significant: pValue < alpha,
+    alpha,
+    controlRate: p1,
+    variantRate: p2,
+    relativeUplift,
+    confidenceInterval: computeConfidenceInterval(control, variant, 1 - alpha),
+  };
+}
+
+/**
+ * Confidence interval for the difference in conversion rate (variant - control).
+ */
+export function computeConfidenceInterval(
+  control: VariantSample,
+  variant: VariantSample,
+  confidenceLevel: number = 0.95
+): ConfidenceInterval {
+  if (control.exposures <= 0 || variant.exposures <= 0) {
+    throw new Error('Both variants must have at least one exposure');
+  }
+
+  const p1 = control.conversions / control.exposures;
+  const p2 = variant.conversions / variant.exposures;
+
+  const se = Math.sqrt(
+    (p1 * (1 - p1)) / control.exposures + (p2 * (1 - p2)) / variant.exposures
+  );
+
+  const z = inverseNormalCdf(1 - (1 - confidenceLevel) / 2);
+  const diff = p2 - p1;
+
+  return {
+    lower: diff - z * se,
+    upper: diff + z * se,
+    confidenceLevel,
+  };
+}
+
+/**
+ * Required sample size per variant to detect `minimumDetectableEffect`
+ * (relative uplift) at the given significance level and power.
+ */
+export function calculateMinimumSampleSize(
+  baselineRate: number,
+  minimumDetectableEffect: number,
+  alpha: number = 0.05,
+  power: number = 0.8
+): PowerAnalysisResult {
+  if (baselineRate <= 0 || baselineRate >= 1) {
+    throw new Error('baselineRate must be in the open interval (0, 1)');
+  }
+  if (minimumDetectableEffect <= 0) {
+    throw new Error('minimumDetectableEffect must be > 0');
+  }
+
+  const p1 = baselineRate;
+  const p2 = baselineRate * (1 + minimumDetectableEffect);
+
+  const zAlpha = inverseNormalCdf(1 - alpha / 2);
+  const zBeta = inverseNormalCdf(power);
+
+  const pooled = (p1 + p2) / 2;
+  const term1 = zAlpha * Math.sqrt(2 * pooled * (1 - pooled));
+  const term2 = zBeta * Math.sqrt(p1 * (1 - p1) + p2 * (1 - p2));
+
+  const n = Math.pow(term1 + term2, 2) / Math.pow(p2 - p1, 2);
+
+  return {
+    requiredSampleSizePerVariant: Math.ceil(n),
+    minimumDetectableEffect,
+    baselineRate,
+    power,
+    alpha,
+  };
+}
+
+/**
+ * Peek-prevention guard for early stopping: an experiment should only be
+ * evaluated for a stopping decision once it has collected the minimum sample
+ * size per variant computed via power analysis. Calling checkSignificance
+ * before that point risks inflated false-positive rates ("p-hacking").
+ */
+export function hasReachedMinimumSampleSize(
+  sample: VariantSample,
+  requiredSampleSizePerVariant: number
+): boolean {
+  return sample.exposures >= requiredSampleSizePerVariant;
+}

--- a/docs/ml/experiment-design-guide.md
+++ b/docs/ml/experiment-design-guide.md
@@ -1,0 +1,85 @@
+# A/B Experiment Design Guide
+
+This guide covers how to design statistically-valid A/B tests using the
+ChenAIKit model registry & experiment framework (`backend/src/services/experimentService.ts`,
+`backend/src/utils/abStatistics.ts`).
+
+## 1. Define a single primary metric
+
+Pick one metric (e.g. `approval_rate`, `fraud_catch_rate`) before starting the
+experiment. Tracking many metrics and reporting whichever looks significant
+after the fact ("p-hacking") inflates the false-positive rate. Secondary
+metrics can be recorded as `metric` events but should not drive the
+ship/no-ship decision.
+
+## 2. Size the experiment before launch
+
+Use `calculateMinimumSampleSize` (wraps a standard two-proportion power
+analysis) to compute how many exposures per variant you need to detect your
+minimum detectable effect (MDE) at your chosen significance level and power:
+
+```ts
+import { calculateMinimumSampleSize } from '../backend/src/utils/abStatistics';
+
+const plan = calculateMinimumSampleSize(
+  /* baselineRate */ 0.12,
+  /* minimumDetectableEffect */ 0.10, // 10% relative uplift
+  /* alpha */ 0.05,
+  /* power */ 0.8
+);
+// plan.requiredSampleSizePerVariant
+```
+
+Set `minimumDetectableEffect` on the experiment (`createExperiment`) so the
+dashboard and API can tell you when you've collected enough data.
+
+## 3. Choose a traffic split
+
+- **50/50** for a straightforward two-variant comparison when you want the
+  fastest path to significance.
+- **90/10** (or similar skewed splits) for higher-risk changes — e.g. rolling
+  out a new fraud detection model — where you want to limit exposure while
+  still collecting a usable treatment sample. Expect the experiment to run
+  longer, since the underpowered arm's sample size still gates readiness.
+
+Traffic weights must sum to 100. Assignment is deterministic and sticky
+(hash of experiment key + subject id), so a user stays in the same variant
+for the life of the experiment even across app servers.
+
+## 4. Multiple variants -> Bonferroni correction
+
+If you configure more than two variants (one control, several treatments),
+set `bonferroniCorrection: true` (this is the default when there are >2
+variants). Each treatment-vs-control comparison is tested at
+`alpha / numberOfTreatments` instead of the raw significance level, which
+controls the family-wise error rate across all the comparisons you're
+running simultaneously.
+
+## 5. Peek prevention
+
+Checking significance before you've reached the planned sample size inflates
+your false-positive rate — every "peek" is another chance to see a
+transient swing and call it real. `getResults()` returns `readyForDecision:
+false` until every variant has reached `powerAnalysis.requiredSampleSizePerVariant`
+exposures. Treat this as a hard gate: don't ship or kill a variant based on
+results collected before `readyForDecision` is `true`.
+
+## 6. Reading the output
+
+For each treatment, `getResults()` returns:
+
+- `conversionRate` — conversions / exposures
+- `significance.pValue` / `significance.significant` — two-proportion z-test
+  vs. control, using the (possibly Bonferroni-corrected) alpha
+- `significance.confidenceInterval` — 95% CI on the difference in
+  conversion rate (variant - control)
+- `significance.relativeUplift` — `(variantRate - controlRate) / controlRate`
+
+A result is only actionable once `readyForDecision` is `true` **and**
+`significance.significant` is `true`.
+
+## 7. Ending an experiment
+
+Call `completeExperiment()` once you've made a decision. If the winning
+variant is a new model version, promote it via `ModelRegistryService.promote()`
+— see the [deployment runbook](./model-deployment-runbook.md).

--- a/docs/ml/model-deployment-runbook.md
+++ b/docs/ml/model-deployment-runbook.md
@@ -1,0 +1,102 @@
+# Model Deployment Runbook
+
+Operational steps for taking a trained model from artifact to production
+using the ChenAIKit model registry.
+
+## Components
+
+- **Registry API**: `/api/v2/ml-models` (`backend/src/routes/mlModels.ts`)
+- **Registry service**: `ModelRegistryService` (`backend/src/services/modelRegistryService.ts`)
+- **Python SDK**: `chenai-mlflow` (`packages/chenai-mlflow`)
+- **CI workflow**: `.github/workflows/model-deployment.yml`
+- **Drift detector**: `ModelDriftDetector` (`backend/src/services/modelDriftDetector.ts`)
+
+## 1. Register a model (one-time)
+
+```python
+from chenai_mlflow import ModelRegistryClient
+
+client = ModelRegistryClient(base_url="https://api.example.com/api/v2")
+model = client.register_model("credit-scoring", task_type="credit_scoring")
+```
+
+Or reuse an existing one: `client.get_or_create_model(...)`.
+
+## 2. Register a new version after training
+
+Every version is content-addressed: the SDK computes the SHA256 of the
+artifact file locally and sends it alongside the artifact URI, so identical
+uploads are always detectable and tampering is visible.
+
+```python
+version = client.register_version(
+    model_id=model["id"],
+    version="2.0.0",
+    artifact_path="ml/models/credit_scoring_v2.joblib",
+    accuracy=0.91,
+    auc=0.94,
+    code_commit=os.environ["GITHUB_SHA"],
+    training_run_id=run_id,
+)
+```
+
+New versions always start in the `staging` stage. This is enforced by
+`ModelRegistryService.register()` — there is no way to register directly
+into production.
+
+## 3. Validate in staging
+
+Run your evaluation suite against the staging version (see
+`ml/evaluation/metrics.py` for the existing credit-scoring / fraud-detection
+metrics). If you want a data-driven comparison rather than a single
+go/no-go check, run it as an A/B experiment — see the
+[experiment design guide](./experiment-design-guide.md).
+
+## 4. Promote to production (approval gate)
+
+Promotion requires an explicit approver and is not automatic:
+
+```python
+client.promote_version(version["id"], approved_by="jane.doe")
+```
+
+This call:
+1. Archives whatever version is currently in `production` for this model.
+2. Moves the target version to `production`, stamping `approvedBy` and
+   `approvedAt`.
+
+There is intentionally no "promote on merge" step in the CI workflow —
+`register-and-deploy` only registers the artifact; promotion is a separate,
+human-triggered action.
+
+## 5. Monitor for drift
+
+Feed periodic AUC measurements (e.g. from a scheduled batch job scoring
+production traffic against ground truth) into the drift detector:
+
+```python
+client.record_drift_check(
+    version_id=production_version["id"],
+    window_start=window_start.isoformat(),
+    window_end=window_end.isoformat(),
+    baseline_auc=0.94,
+    observed_auc=0.905,
+)
+```
+
+- Alerts when AUC drops more than **3%** from baseline (`alertThresholdPct`,
+  configurable per call).
+- Automatically rolls back to the previous production version when the drop
+  exceeds the **canary threshold** (default 5%) — see
+  [rollback procedures](./rollback-procedures.md) for what that does under
+  the hood.
+
+## 6. CI/CD
+
+`.github/workflows/model-deployment.yml` runs on pushes touching `ml/**`:
+
+1. `train` — regenerates synthetic data, preprocesses, trains.
+2. `validate` — runs `ml/evaluation/metrics.py` as a gate; the job fails (and
+   blocks registration) if evaluation errors out.
+3. `register-and-deploy` — registers the resulting artifact with the
+   registry via `chenai-mlflow`. Promotion is left manual (see step 4).

--- a/docs/ml/rollback-procedures.md
+++ b/docs/ml/rollback-procedures.md
@@ -1,0 +1,71 @@
+# Model Rollback Procedures
+
+## Manual rollback
+
+Use this when you've identified a problem with the current production model
+version (via monitoring, an A/B test result, or a support escalation) and
+want to restore a previous version immediately.
+
+### Via API
+
+```
+POST /api/v2/ml-models/:modelId/rollback
+{
+  "targetVersionId": "<id of the version to restore>",
+  "actor": "<your name or id>"
+}
+```
+
+### Via the SDK
+
+```python
+client.rollback(model_id, target_version_id, actor="jane.doe")
+```
+
+### Via the dashboard
+
+The `ExperimentDashboard` frontend component (`frontend/src/components/ExperimentDashboard.tsx`)
+has a "Rollback model" button on each experiment's detail view. It prompts
+for the target version id and an actor identifier, then calls the same
+rollback endpoint.
+
+### What happens
+
+`ModelRegistryService.rollback()`:
+1. Verifies the target version belongs to the specified model.
+2. Archives whatever version is currently `production` (sets `stage:
+   'archived'`, `archivedAt: now`).
+3. Restores the target version to `production` (stamps `promotedAt`,
+   `approvedBy: actor`, `approvedAt: now`).
+
+Rollback does **not** require the same approval gate as a forward promotion —
+being able to act quickly during an incident matters more than requiring a
+second approver, since rollback is itself the safety mechanism.
+
+## Automated canary rollback
+
+`ModelDriftDetector.recordCheck()` runs this automatically whenever a drift
+check shows degradation beyond the experiment/model's canary threshold
+(default 5% AUC drop, configurable via `canaryThresholdPct`):
+
+1. Finds the most recently archived version for the same model (i.e. the
+   version that was in production immediately before the current one).
+2. Calls the same `ModelRegistryService.rollback()` path, with
+   `actor: 'model-drift-detector'` (or a custom `autoRollbackActor`).
+3. Marks the drift check record's `alertSent: true`.
+
+If no archived version exists (e.g. this is the model's first production
+version), auto-rollback is skipped and an error is logged — there is nothing
+safe to roll back to, so this needs human intervention.
+
+## After a rollback
+
+1. Check `GET /api/v2/ml-models/:modelId/versions/production` to confirm the
+   expected version is now serving.
+2. Review `GET /api/v2/ml-models/versions/:versionId/drift-checks` for the
+   history that triggered the rollback (if automated).
+3. If the rollback was triggered by an A/B experiment result, call
+   `completeExperiment()` (or `pauseExperiment()` if you plan to re-run it
+   later) so the experiment stops accepting new assignments.
+4. File a follow-up to investigate the root cause of the regression before
+   attempting to re-promote the problematic version.

--- a/examples/credit-score-ab-test/README.md
+++ b/examples/credit-score-ab-test/README.md
@@ -1,0 +1,42 @@
+# Example: Credit Score v2.0 vs v1.0 (90/10 rollout)
+
+Demonstrates the full model registry + A/B testing flow from
+[issue #254](https://github.com/nexoraorg/chenaikit/issues/254): registering
+two model versions, running a 90/10 canary experiment between them, and
+reading back statistically-rigorous results.
+
+## Prerequisites
+
+- The backend running locally (`cd backend && pnpm dev`), or any deployed
+  ChenAIKit backend reachable via `CHENAIKIT_API_URL`.
+- The `chenai-mlflow` SDK installed: `pip install -e packages/chenai-mlflow`.
+
+## Run it
+
+```bash
+export CHENAIKIT_API_URL=http://localhost:3000/api/v2
+python examples/credit-score-ab-test/run_experiment.py
+```
+
+## What it does
+
+1. Registers (or reuses) a `credit-scoring` model.
+2. Registers two versions: `1.0.0` (control, already in production) and
+   `2.0.0` (treatment, the improved model).
+3. Promotes `1.0.0` to production as the baseline.
+4. Creates an experiment with a **90/10** traffic split — 90% of traffic
+   stays on the proven v1.0 model, 10% is routed to the new v2.0 model,
+   limiting exposure to the unproven version while still collecting a
+   usable sample.
+5. Simulates 5,000 subjects being assigned and converting (approved for
+   credit) at slightly different rates for each variant.
+6. Prints the statistical results: conversion rates, p-value, confidence
+   interval, and whether the experiment has reached the minimum sample size
+   needed to make a decision (peek prevention).
+7. If v2.0 wins with statistical significance, promotes it to production
+   via the same approval-gated `promote_version()` call used in production
+   deployments.
+
+This mirrors a gradual rollout pattern (10% -> 50% -> 100%) — rerunning
+`create_experiment` with updated `trafficWeight` values lets you widen the
+rollout once you're confident in the results.

--- a/examples/credit-score-ab-test/run_experiment.py
+++ b/examples/credit-score-ab-test/run_experiment.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Example: credit score model v2.0 vs v1.0 with a 90/10 traffic split.
+
+Registers two model versions, runs a 90/10 canary experiment between them,
+simulates traffic, and reports statistically-rigorous results using the
+chenai-mlflow SDK against a running ChenAIKit backend.
+"""
+
+import hashlib
+import random
+import sys
+import time
+
+from chenai_mlflow import ModelRegistryClient
+from chenai_mlflow.errors import ChenAIMLflowError
+
+# Simulated "true" conversion (approval) rates for the demo. In a real
+# rollout these come from actual user outcomes, not a coin flip.
+V1_TRUE_APPROVAL_RATE = 0.62
+V2_TRUE_APPROVAL_RATE = 0.68  # v2.0 is the improved model
+SIMULATED_SUBJECTS = 5000
+
+
+def fake_artifact_path(version: str) -> str:
+    # In a real pipeline this is the path to a trained .pkl/.joblib file
+    # produced by ml/training/train_credit_score.py. For this example we
+    # just need a stable string to hash for content addressing.
+    return f"ml/models/credit_scoring_{version}.joblib"
+
+
+def main() -> int:
+    client = ModelRegistryClient()  # reads CHENAIKIT_API_URL from env
+
+    print(f"Using backend: {client.base_url}")
+
+    try:
+        model = client.get_or_create_model("credit-scoring", task_type="credit_scoring")
+        print(f"Model: {model['name']} ({model['id']})")
+
+        v1 = client.register_version(
+            model_id=model["id"],
+            version="1.0.0",
+            artifact_path=fake_artifact_path("v1"),
+            accuracy=0.87,
+            auc=0.90,
+        )
+        print(f"Registered v1.0.0 ({v1['id']}), stage={v1['stage']}")
+
+        v2 = client.register_version(
+            model_id=model["id"],
+            version="2.0.0",
+            artifact_path=fake_artifact_path("v2"),
+            accuracy=0.91,
+            auc=0.94,
+        )
+        print(f"Registered v2.0.0 ({v2['id']}), stage={v2['stage']}")
+
+        client.promote_version(v1["id"], approved_by="example-script")
+        print("Promoted v1.0.0 to production as the baseline")
+
+        experiment = client.create_experiment(
+            key=f"credit-score-v2-rollout-{int(time.time())}",
+            name="Credit score v2.0 vs v1.0 (90/10 canary)",
+            model_id=model["id"],
+            metric="approval_rate",
+            hypothesis="v2.0 improves approval rate without increasing default risk",
+            minimum_detectable_effect=0.05,
+            variants=[
+                {"name": "control-v1", "modelVersionId": v1["id"], "trafficWeight": 90, "isControl": True},
+                {"name": "treatment-v2", "modelVersionId": v2["id"], "trafficWeight": 10},
+            ],
+        )
+        print(f"Created experiment {experiment['key']} ({experiment['id']})")
+
+        client.start_experiment(experiment["id"])
+        print(f"Simulating {SIMULATED_SUBJECTS} subjects...")
+
+        for i in range(SIMULATED_SUBJECTS):
+            subject_id = f"applicant-{i}"
+            variant = client.assign_variant(experiment["id"], subject_id)
+
+            # Deterministic pseudo-random outcome per subject so re-running
+            # this script is reproducible.
+            seed = int(hashlib.sha256(subject_id.encode()).hexdigest()[:8], 16)
+            rng = random.Random(seed)
+
+            true_rate = V2_TRUE_APPROVAL_RATE if variant["name"] == "treatment-v2" else V1_TRUE_APPROVAL_RATE
+            if rng.random() < true_rate:
+                client.track_conversion(experiment["id"], subject_id)
+
+        results = client.get_results(experiment["id"])
+        print_results(results)
+
+        treatment = results["treatments"][0]
+        if results["readyForDecision"] and treatment.get("significance", {}).get("significant"):
+            print("\nv2.0 wins with statistical significance — promoting to production.")
+            client.promote_version(v2["id"], approved_by="example-script")
+            client.complete_experiment(experiment["id"])
+        else:
+            print("\nNot ready to decide yet (or v2.0 did not win) — leaving v1.0 in production.")
+
+        return 0
+
+    except ChenAIMLflowError as err:
+        print(f"Error talking to the registry API: {err}", file=sys.stderr)
+        print("Is the backend running? See examples/credit-score-ab-test/README.md", file=sys.stderr)
+        return 1
+
+
+def print_results(results: dict) -> None:
+    control = results["control"]
+    print("\n--- Results ---")
+    print(f"Control ({control['variant']['name']}): {control['conversionRate']:.2%} "
+          f"({control['conversions']}/{control['exposures']})")
+
+    for treatment in results["treatments"]:
+        print(f"Treatment ({treatment['variant']['name']}): {treatment['conversionRate']:.2%} "
+              f"({treatment['conversions']}/{treatment['exposures']})")
+
+        sig = treatment.get("significance")
+        if sig:
+            print(f"  p-value: {sig['pValue']:.4f} (alpha={sig['alpha']:.4f})")
+            print(f"  relative uplift: {sig['relativeUplift']:.2%}")
+            ci = sig["confidenceInterval"]
+            print(f"  95% CI on diff: [{ci['lower']:.2%}, {ci['upper']:.2%}]")
+            print(f"  significant: {sig['significant']}")
+
+    power = results.get("powerAnalysis")
+    if power:
+        print(f"\nRequired sample size per variant: {power['requiredSampleSizePerVariant']}")
+    print(f"Ready for decision (peek prevention passed): {results['readyForDecision']}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/frontend/src/components/ExperimentDashboard.tsx
+++ b/frontend/src/components/ExperimentDashboard.tsx
@@ -1,0 +1,399 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  Box,
+  Card,
+  CardContent,
+  Typography,
+  Grid,
+  Chip,
+  List,
+  ListItemButton,
+  ListItemText,
+  Button,
+  Alert,
+  Divider,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Stack,
+} from '@mui/material';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip as RechartsTooltip,
+  ResponsiveContainer,
+  Legend,
+  ReferenceLine,
+} from 'recharts';
+import {
+  Experiment,
+  ExperimentResults,
+  listExperiments,
+  getExperimentResults,
+  rollbackModel,
+  startExperiment,
+  pauseExperiment,
+} from '../utils/mlModelsApi';
+import { SkeletonCard } from './SkeletonCard';
+
+const STATUS_COLORS: Record<Experiment['status'], 'default' | 'success' | 'warning' | 'info' | 'error'> = {
+  draft: 'default',
+  running: 'success',
+  paused: 'warning',
+  completed: 'info',
+  rolled_back: 'error',
+};
+
+function formatPct(value: number): string {
+  return `${(value * 100).toFixed(2)}%`;
+}
+
+interface RollbackDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: (targetVersionId: string, actor: string) => Promise<void>;
+  modelId: string | null;
+}
+
+const RollbackDialog: React.FC<RollbackDialogProps> = ({ open, onClose, onConfirm }) => {
+  const [targetVersionId, setTargetVersionId] = useState('');
+  const [actor, setActor] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleConfirm = async () => {
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onConfirm(targetVersionId, actor);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Rollback failed');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Roll back model</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          {error && <Alert severity="error">{error}</Alert>}
+          <TextField
+            label="Target version ID"
+            value={targetVersionId}
+            onChange={(e) => setTargetVersionId(e.target.value)}
+            helperText="The model version to restore to production"
+            fullWidth
+          />
+          <TextField
+            label="Your name / actor id"
+            value={actor}
+            onChange={(e) => setActor(e.target.value)}
+            fullWidth
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={submitting}>Cancel</Button>
+        <Button
+          onClick={handleConfirm}
+          color="error"
+          variant="contained"
+          disabled={submitting || !targetVersionId || !actor}
+        >
+          {submitting ? 'Rolling back…' : 'Confirm rollback'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export const ExperimentDashboard: React.FC = () => {
+  const [experiments, setExperiments] = useState<Experiment[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [results, setResults] = useState<ExperimentResults | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [resultsLoading, setResultsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [rollbackOpen, setRollbackOpen] = useState(false);
+
+  const loadExperiments = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await listExperiments();
+      setExperiments(data);
+      if (!selectedId && data.length > 0) {
+        setSelectedId(data[0].id);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load experiments');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const loadResults = useCallback(async (experimentId: string) => {
+    setResultsLoading(true);
+    try {
+      const data = await getExperimentResults(experimentId);
+      setResults(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load experiment results');
+    } finally {
+      setResultsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadExperiments();
+  }, [loadExperiments]);
+
+  useEffect(() => {
+    if (selectedId) {
+      loadResults(selectedId);
+    }
+  }, [selectedId, loadResults]);
+
+  const handleToggleStatus = async (experiment: Experiment) => {
+    try {
+      if (experiment.status === 'running') {
+        await pauseExperiment(experiment.id);
+      } else {
+        await startExperiment(experiment.id);
+      }
+      await loadExperiments();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update experiment status');
+    }
+  };
+
+  const handleRollback = async (targetVersionId: string, actor: string) => {
+    if (!results) return;
+    await rollbackModel(results.experiment.modelId, targetVersionId, actor);
+    await loadResults(results.experiment.id);
+  };
+
+  const chartData = results
+    ? [
+        {
+          name: results.control.variant.name,
+          conversionRate: results.control.conversionRate * 100,
+          exposures: results.control.exposures,
+          isControl: true,
+        },
+        ...results.treatments.map((t) => ({
+          name: t.variant.name,
+          conversionRate: t.conversionRate * 100,
+          exposures: t.exposures,
+          isControl: false,
+        })),
+      ]
+    : [];
+
+  if (loading) {
+    return <SkeletonCard />;
+  }
+
+  return (
+    <Box sx={{ display: 'flex', gap: 3, flexDirection: { xs: 'column', md: 'row' } }}>
+      {error && (
+        <Alert severity="error" sx={{ width: '100%' }} onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
+
+      <Card sx={{ width: { xs: '100%', md: 320 }, flexShrink: 0 }}>
+        <CardContent>
+          <Typography variant="h6" gutterBottom>
+            Experiments
+          </Typography>
+          <List disablePadding>
+            {experiments.map((experiment) => (
+              <ListItemButton
+                key={experiment.id}
+                selected={experiment.id === selectedId}
+                onClick={() => setSelectedId(experiment.id)}
+              >
+                <ListItemText
+                  primary={experiment.name}
+                  secondary={
+                    <Chip
+                      size="small"
+                      label={experiment.status}
+                      color={STATUS_COLORS[experiment.status]}
+                      sx={{ mt: 0.5 }}
+                    />
+                  }
+                />
+              </ListItemButton>
+            ))}
+            {experiments.length === 0 && (
+              <Typography variant="body2" color="text.secondary">
+                No experiments yet.
+              </Typography>
+            )}
+          </List>
+        </CardContent>
+      </Card>
+
+      <Box sx={{ flex: 1 }}>
+        {resultsLoading && <SkeletonCard />}
+
+        {!resultsLoading && results && (
+          <Stack spacing={3}>
+            <Card>
+              <CardContent>
+                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', flexWrap: 'wrap', gap: 2 }}>
+                  <Box>
+                    <Typography variant="h5">{results.experiment.name}</Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      {results.experiment.description || 'No description'}
+                    </Typography>
+                    <Chip
+                      size="small"
+                      sx={{ mt: 1 }}
+                      label={results.experiment.status}
+                      color={STATUS_COLORS[results.experiment.status]}
+                    />
+                  </Box>
+                  <Stack direction="row" spacing={1}>
+                    <Button
+                      variant="outlined"
+                      onClick={() => handleToggleStatus(results.experiment)}
+                    >
+                      {results.experiment.status === 'running' ? 'Pause' : 'Start'}
+                    </Button>
+                    <Button
+                      variant="contained"
+                      color="error"
+                      onClick={() => setRollbackOpen(true)}
+                    >
+                      Rollback model
+                    </Button>
+                  </Stack>
+                </Box>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardContent>
+                <Typography variant="h6" gutterBottom>
+                  Variant comparison — conversion rate on &ldquo;{results.experiment.metric}&rdquo;
+                </Typography>
+                <ResponsiveContainer width="100%" height={280}>
+                  <BarChart data={chartData}>
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <XAxis dataKey="name" />
+                    <YAxis unit="%" />
+                    <RechartsTooltip formatter={(value) => `${Number(value).toFixed(2)}%`} />
+                    <Legend />
+                    <ReferenceLine
+                      y={results.control.conversionRate * 100}
+                      stroke="#888"
+                      strokeDasharray="4 4"
+                      label="control"
+                    />
+                    <Bar dataKey="conversionRate" name="Conversion rate" fill="#3b82f6" />
+                  </BarChart>
+                </ResponsiveContainer>
+              </CardContent>
+            </Card>
+
+            <Grid container spacing={2}>
+              <Grid item xs={12} md={6}>
+                <Card>
+                  <CardContent>
+                    <Typography variant="subtitle1" gutterBottom>
+                      Control — {results.control.variant.name}
+                    </Typography>
+                    <Typography variant="h4">{formatPct(results.control.conversionRate)}</Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      {results.control.conversions} / {results.control.exposures} exposures
+                    </Typography>
+                  </CardContent>
+                </Card>
+              </Grid>
+
+              {results.treatments.map((treatment) => (
+                <Grid item xs={12} md={6} key={treatment.variant.id}>
+                  <Card>
+                    <CardContent>
+                      <Typography variant="subtitle1" gutterBottom>
+                        {treatment.variant.name}
+                      </Typography>
+                      <Typography variant="h4">{formatPct(treatment.conversionRate)}</Typography>
+                      <Typography variant="body2" color="text.secondary">
+                        {treatment.conversions} / {treatment.exposures} exposures
+                      </Typography>
+                      <Divider sx={{ my: 1 }} />
+                      {treatment.significance ? (
+                        <>
+                          <Chip
+                            size="small"
+                            label={
+                              treatment.significance.significant
+                                ? 'Statistically significant'
+                                : 'Not significant'
+                            }
+                            color={treatment.significance.significant ? 'success' : 'default'}
+                            sx={{ mb: 1 }}
+                          />
+                          <Typography variant="body2">
+                            p-value: {treatment.significance.pValue.toFixed(4)} (α ={' '}
+                            {treatment.significance.alpha.toFixed(4)})
+                          </Typography>
+                          <Typography variant="body2">
+                            Relative uplift: {formatPct(treatment.significance.relativeUplift)}
+                          </Typography>
+                          <Typography variant="body2">
+                            95% CI on diff: [{formatPct(treatment.significance.confidenceInterval.lower)},{' '}
+                            {formatPct(treatment.significance.confidenceInterval.upper)}]
+                          </Typography>
+                        </>
+                      ) : (
+                        <Typography variant="body2" color="text.secondary">
+                          Not enough data yet for significance testing.
+                        </Typography>
+                      )}
+                    </CardContent>
+                  </Card>
+                </Grid>
+              ))}
+            </Grid>
+
+            {results.powerAnalysis && (
+              <Alert severity={results.readyForDecision ? 'success' : 'info'}>
+                {results.readyForDecision
+                  ? `Minimum sample size (${results.powerAnalysis.requiredSampleSizePerVariant} per variant) reached — safe to make a decision.`
+                  : `Still collecting data: need ${results.powerAnalysis.requiredSampleSizePerVariant} exposures per variant before checking significance (peek prevention).`}
+              </Alert>
+            )}
+          </Stack>
+        )}
+
+        {!resultsLoading && !results && experiments.length > 0 && (
+          <Typography variant="body2" color="text.secondary">
+            Select an experiment to view results.
+          </Typography>
+        )}
+      </Box>
+
+      <RollbackDialog
+        open={rollbackOpen}
+        onClose={() => setRollbackOpen(false)}
+        onConfirm={handleRollback}
+        modelId={results?.experiment.modelId ?? null}
+      />
+    </Box>
+  );
+};
+
+export default ExperimentDashboard;

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -51,3 +51,6 @@ export { LoadingSpinner } from './LoadingSpinner';
 export { SkeletonCard } from './SkeletonCard';
 export { SkeletonTable } from './SkeletonTable';
 export { SkeletonChart } from './SkeletonChart';
+
+// ML model versioning & A/B testing
+export { default as ExperimentDashboard } from './ExperimentDashboard';

--- a/frontend/src/utils/mlModelsApi.ts
+++ b/frontend/src/utils/mlModelsApi.ts
@@ -1,0 +1,130 @@
+import { requestSettingsApi } from './settingsApi';
+
+const API_BASE = '/api/v2/ml-models';
+
+export interface MLModel {
+  id: string;
+  name: string;
+  description: string;
+  taskType: string;
+  createdAt: string;
+}
+
+export interface MLModelVersion {
+  id: string;
+  modelId: string;
+  version: string;
+  stage: 'staging' | 'production' | 'archived';
+  accuracy: number | null;
+  precision: number | null;
+  recall: number | null;
+  f1Score: number | null;
+  auc: number | null;
+  createdAt: string;
+  promotedAt: string | null;
+}
+
+export interface ExperimentVariant {
+  id: string;
+  experimentId: string;
+  modelVersionId: string;
+  name: string;
+  isControl: boolean;
+  trafficWeight: number;
+}
+
+export interface Experiment {
+  id: string;
+  key: string;
+  name: string;
+  description: string;
+  modelId: string;
+  status: 'draft' | 'running' | 'paused' | 'completed' | 'rolled_back';
+  metric: string;
+  significanceLevel: number;
+  power: number;
+  minimumDetectableEffect: number | null;
+  bonferroniCorrection: boolean;
+  createdAt: string;
+  variants?: ExperimentVariant[];
+}
+
+export interface SignificanceResult {
+  pValue: number;
+  zScore: number;
+  significant: boolean;
+  alpha: number;
+  controlRate: number;
+  variantRate: number;
+  relativeUplift: number;
+  confidenceInterval: { lower: number; upper: number; confidenceLevel: number };
+}
+
+export interface VariantResult {
+  variant: ExperimentVariant;
+  exposures: number;
+  conversions: number;
+  conversionRate: number;
+  significance?: SignificanceResult;
+}
+
+export interface ExperimentResults {
+  experiment: Experiment;
+  control: VariantResult;
+  treatments: VariantResult[];
+  powerAnalysis: {
+    requiredSampleSizePerVariant: number;
+    minimumDetectableEffect: number;
+    baselineRate: number;
+    power: number;
+    alpha: number;
+  } | null;
+  readyForDecision: boolean;
+}
+
+export const listModels = () => requestSettingsApi<{ success: boolean; data: MLModel[] }>({
+  url: `${API_BASE}`,
+  method: 'GET',
+}).then((r) => r.data);
+
+export const listExperiments = () => requestSettingsApi<{ success: boolean; data: Experiment[] }>({
+  url: `${API_BASE}/experiments`,
+  method: 'GET',
+}).then((r) => r.data);
+
+export const getExperiment = (experimentId: string) =>
+  requestSettingsApi<{ success: boolean; data: Experiment }>({
+    url: `${API_BASE}/experiments/${experimentId}`,
+    method: 'GET',
+  }).then((r) => r.data);
+
+export const getExperimentResults = (experimentId: string) =>
+  requestSettingsApi<{ success: boolean; data: ExperimentResults }>({
+    url: `${API_BASE}/experiments/${experimentId}/results`,
+    method: 'GET',
+  }).then((r) => r.data);
+
+export const listModelVersions = (modelId: string) =>
+  requestSettingsApi<{ success: boolean; data: MLModelVersion[] }>({
+    url: `${API_BASE}/${modelId}/versions`,
+    method: 'GET',
+  }).then((r) => r.data);
+
+export const rollbackModel = (modelId: string, targetVersionId: string, actor: string) =>
+  requestSettingsApi<{ success: boolean; data: MLModelVersion }>({
+    url: `${API_BASE}/${modelId}/rollback`,
+    method: 'POST',
+    data: { targetVersionId, actor },
+  }).then((r) => r.data);
+
+export const startExperiment = (experimentId: string) =>
+  requestSettingsApi<{ success: boolean; data: Experiment }>({
+    url: `${API_BASE}/experiments/${experimentId}/start`,
+    method: 'POST',
+  }).then((r) => r.data);
+
+export const pauseExperiment = (experimentId: string) =>
+  requestSettingsApi<{ success: boolean; data: Experiment }>({
+    url: `${API_BASE}/experiments/${experimentId}/pause`,
+    method: 'POST',
+  }).then((r) => r.data);

--- a/packages/chenai-mlflow/README.md
+++ b/packages/chenai-mlflow/README.md
@@ -1,0 +1,69 @@
+# chenai-mlflow
+
+Python SDK for the ChenAIKit ML model registry and A/B testing framework.
+Use it from training scripts to register model versions, promote them
+through the staging -> production approval gate, and drive A/B experiments.
+
+## Install
+
+```bash
+pip install -e packages/chenai-mlflow
+```
+
+## Usage
+
+```python
+from chenai_mlflow import ModelRegistryClient
+
+client = ModelRegistryClient(base_url="http://localhost:3000/api/v2")
+
+model = client.get_or_create_model("credit-scoring", task_type="credit_scoring")
+
+version = client.register_version(
+    model_id=model["id"],
+    version="2.0.0",
+    artifact_path="ml/models/credit_scoring_v2.joblib",
+    accuracy=0.91,
+    auc=0.94,
+    code_commit="abc1234",
+    training_run_id="run-042",
+)
+
+# Promotion requires an approval gate.
+client.promote_version(version["id"], approved_by="jane.doe")
+```
+
+### A/B testing
+
+```python
+experiment = client.create_experiment(
+    key="credit-score-v2-rollout",
+    name="Credit score v2 vs v1",
+    model_id=model["id"],
+    metric="approval_rate",
+    minimum_detectable_effect=0.02,
+    variants=[
+        {"name": "control", "modelVersionId": v1_id, "trafficWeight": 90, "isControl": True},
+        {"name": "treatment", "modelVersionId": v2_id, "trafficWeight": 10},
+    ],
+)
+client.start_experiment(experiment["id"])
+
+variant = client.assign_variant(experiment["id"], subject_id="user-123")
+client.track_conversion(experiment["id"], subject_id="user-123")
+
+results = client.get_results(experiment["id"])
+```
+
+## Configuration
+
+The client reads `CHENAIKIT_API_URL` if `base_url` is not passed explicitly
+(defaults to `http://localhost:3000/api/v2`).
+
+## Development
+
+```bash
+cd packages/chenai-mlflow
+pip install -e ".[dev]"
+pytest
+```

--- a/packages/chenai-mlflow/chenai_mlflow/__init__.py
+++ b/packages/chenai-mlflow/chenai_mlflow/__init__.py
@@ -1,0 +1,15 @@
+"""chenai-mlflow: Python SDK for the ChenAIKit ML model registry and A/B testing API."""
+
+from .client import ModelRegistryClient
+from .hashing import hash_artifact
+from .errors import ChenAIMLflowError, ModelNotFoundError, ConflictError
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "ModelRegistryClient",
+    "hash_artifact",
+    "ChenAIMLflowError",
+    "ModelNotFoundError",
+    "ConflictError",
+]

--- a/packages/chenai-mlflow/chenai_mlflow/client.py
+++ b/packages/chenai-mlflow/chenai_mlflow/client.py
@@ -1,0 +1,223 @@
+"""HTTP client for the ChenAIKit model registry & A/B experiment API."""
+
+import os
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from .errors import ChenAIMLflowError, ConflictError, ModelNotFoundError, ValidationError
+from .hashing import hash_artifact
+
+
+class ModelRegistryClient:
+    """Client for registering models, promoting versions, and managing
+    A/B experiments against a ChenAIKit backend instance.
+
+    Example:
+        >>> client = ModelRegistryClient(base_url="http://localhost:3000/api/v2")
+        >>> model = client.get_or_create_model("credit-scoring", task_type="credit_scoring")
+        >>> version = client.register_version(
+        ...     model_id=model["id"],
+        ...     version="2.0.0",
+        ...     artifact_path="models/credit_scoring_v2.joblib",
+        ...     accuracy=0.91,
+        ...     auc=0.94,
+        ... )
+        >>> client.promote_version(version["id"], approved_by="jane.doe")
+    """
+
+    def __init__(self, base_url: Optional[str] = None, timeout: float = 30.0):
+        self.base_url = (base_url or os.environ.get("CHENAIKIT_API_URL", "http://localhost:3000/api/v2")).rstrip("/")
+        self.timeout = timeout
+        self.session = requests.Session()
+
+    def _request(self, method: str, path: str, **kwargs) -> Any:
+        url = f"{self.base_url}{path}"
+        response = self.session.request(method, url, timeout=self.timeout, **kwargs)
+
+        if response.status_code == 404:
+            raise ModelNotFoundError(response.text)
+        if response.status_code == 409:
+            raise ConflictError(response.text)
+        if response.status_code == 400:
+            raise ValidationError(response.text)
+        if response.status_code >= 400:
+            raise ChenAIMLflowError(f"Request failed ({response.status_code}): {response.text}")
+
+        if response.status_code == 204 or not response.content:
+            return None
+
+        body = response.json()
+        return body.get("data", body)
+
+    # -- Model registry ----------------------------------------------------
+
+    def register_model(self, name: str, task_type: str, description: str = "") -> Dict[str, Any]:
+        return self._request(
+            "POST",
+            "/ml-models",
+            json={"name": name, "taskType": task_type, "description": description},
+        )
+
+    def list_models(self) -> List[Dict[str, Any]]:
+        return self._request("GET", "/ml-models")
+
+    def get_or_create_model(self, name: str, task_type: str, description: str = "") -> Dict[str, Any]:
+        for model in self.list_models():
+            if model["name"] == name:
+                return model
+        return self.register_model(name, task_type, description)
+
+    def register_version(
+        self,
+        model_id: str,
+        version: str,
+        artifact_path: str,
+        content_hash: Optional[str] = None,
+        framework_version: Optional[str] = None,
+        accuracy: Optional[float] = None,
+        precision: Optional[float] = None,
+        recall: Optional[float] = None,
+        f1_score: Optional[float] = None,
+        auc: Optional[float] = None,
+        training_data_uri: Optional[str] = None,
+        hyperparameters: Optional[Dict[str, Any]] = None,
+        dataset_version: Optional[str] = None,
+        code_commit: Optional[str] = None,
+        training_run_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Registers a new model version. If `content_hash` is omitted, it is
+        computed locally from the artifact file (SHA256) before upload."""
+        computed_hash = content_hash or hash_artifact(artifact_path)
+
+        payload = {
+            "version": version,
+            "artifactUri": artifact_path,
+            "contentHash": computed_hash,
+            "frameworkVersion": framework_version,
+            "accuracy": accuracy,
+            "precision": precision,
+            "recall": recall,
+            "f1Score": f1_score,
+            "auc": auc,
+            "trainingDataUri": training_data_uri,
+            "hyperparameters": hyperparameters or {},
+            "datasetVersion": dataset_version,
+            "codeCommit": code_commit,
+            "trainingRunId": training_run_id,
+        }
+        payload = {k: v for k, v in payload.items() if v is not None}
+
+        return self._request("POST", f"/ml-models/{model_id}/versions", json=payload)
+
+    def list_versions(self, model_id: str, stage: Optional[str] = None) -> List[Dict[str, Any]]:
+        params = {"stage": stage} if stage else {}
+        return self._request("GET", f"/ml-models/{model_id}/versions", params=params)
+
+    def get_production_version(self, model_id: str) -> Optional[Dict[str, Any]]:
+        return self._request("GET", f"/ml-models/{model_id}/versions/production")
+
+    def promote_version(self, version_id: str, approved_by: str) -> Dict[str, Any]:
+        """Promotes a staging version to production. Requires an approval
+        gate: `approved_by` must identify the approving actor."""
+        return self._request(
+            "POST",
+            f"/ml-models/versions/{version_id}/promote",
+            json={"approvedBy": approved_by},
+        )
+
+    def rollback(self, model_id: str, target_version_id: str, actor: str) -> Dict[str, Any]:
+        return self._request(
+            "POST",
+            f"/ml-models/{model_id}/rollback",
+            json={"targetVersionId": target_version_id, "actor": actor},
+        )
+
+    def record_drift_check(
+        self,
+        version_id: str,
+        window_start: str,
+        window_end: str,
+        baseline_auc: float,
+        observed_auc: float,
+        alert_threshold_pct: Optional[float] = None,
+        canary_threshold_pct: Optional[float] = None,
+        auto_rollback_actor: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        payload = {
+            "windowStart": window_start,
+            "windowEnd": window_end,
+            "baselineAuc": baseline_auc,
+            "observedAuc": observed_auc,
+            "alertThresholdPct": alert_threshold_pct,
+            "canaryThresholdPct": canary_threshold_pct,
+            "autoRollbackActor": auto_rollback_actor,
+        }
+        payload = {k: v for k, v in payload.items() if v is not None}
+        return self._request("POST", f"/ml-models/versions/{version_id}/drift-checks", json=payload)
+
+    # -- Experiments ---------------------------------------------------------
+
+    def create_experiment(
+        self,
+        key: str,
+        name: str,
+        model_id: str,
+        metric: str,
+        variants: List[Dict[str, Any]],
+        hypothesis: str = "",
+        minimum_detectable_effect: Optional[float] = None,
+        significance_level: float = 0.05,
+        power: float = 0.8,
+        bonferroni_correction: Optional[bool] = None,
+        canary_threshold_pct: float = 5.0,
+        canary_window_hours: int = 24,
+    ) -> Dict[str, Any]:
+        """Creates an A/B experiment.
+
+        `variants` is a list of dicts: `{"name": str, "modelVersionId": str,
+        "trafficWeight": float, "isControl": bool}`. Traffic weights must sum
+        to 100 (e.g. a 90/10 rollout is `[{"trafficWeight": 90, ...},
+        {"trafficWeight": 10, ...}]`).
+        """
+        payload = {
+            "key": key,
+            "name": name,
+            "modelId": model_id,
+            "metric": metric,
+            "hypothesis": hypothesis,
+            "minimumDetectableEffect": minimum_detectable_effect,
+            "significanceLevel": significance_level,
+            "power": power,
+            "bonferroniCorrection": bonferroni_correction,
+            "canaryThresholdPct": canary_threshold_pct,
+            "canaryWindowHours": canary_window_hours,
+            "variants": variants,
+        }
+        payload = {k: v for k, v in payload.items() if v is not None}
+        return self._request("POST", "/ml-models/experiments", json=payload)
+
+    def start_experiment(self, experiment_id: str) -> Dict[str, Any]:
+        return self._request("POST", f"/ml-models/experiments/{experiment_id}/start")
+
+    def pause_experiment(self, experiment_id: str) -> Dict[str, Any]:
+        return self._request("POST", f"/ml-models/experiments/{experiment_id}/pause")
+
+    def complete_experiment(self, experiment_id: str) -> Dict[str, Any]:
+        return self._request("POST", f"/ml-models/experiments/{experiment_id}/complete")
+
+    def assign_variant(self, experiment_id: str, subject_id: str) -> Dict[str, Any]:
+        return self._request(
+            "POST",
+            f"/ml-models/experiments/{experiment_id}/assign",
+            json={"subjectId": subject_id},
+        )
+
+    def track_conversion(self, experiment_id: str, subject_id: str, metric_value: Optional[float] = None) -> None:
+        payload: Dict[str, Any] = {"subjectId": subject_id}
+        if metric_value is not None:
+            payload["metricValue"] = metric_value
+        self._request("POST", f"/ml-models/experiments/{experiment_id}/convert", json=payload)
+
+    def get_results(self, experiment_id: str) -> Dict[str, Any]:
+        return self._request("GET", f"/ml-models/experiments/{experiment_id}/results")

--- a/packages/chenai-mlflow/chenai_mlflow/errors.py
+++ b/packages/chenai-mlflow/chenai_mlflow/errors.py
@@ -1,0 +1,14 @@
+class ChenAIMLflowError(Exception):
+    """Base error for all chenai-mlflow SDK failures."""
+
+
+class ModelNotFoundError(ChenAIMLflowError):
+    """Raised when a model or model version cannot be found."""
+
+
+class ConflictError(ChenAIMLflowError):
+    """Raised when attempting to register a model/version that already exists."""
+
+
+class ValidationError(ChenAIMLflowError):
+    """Raised when the API rejects a request due to invalid input."""

--- a/packages/chenai-mlflow/chenai_mlflow/hashing.py
+++ b/packages/chenai-mlflow/chenai_mlflow/hashing.py
@@ -1,0 +1,19 @@
+"""Content-addressable hashing helpers for model artifacts."""
+
+import hashlib
+from pathlib import Path
+from typing import Union
+
+
+def hash_artifact(artifact_path: Union[str, Path], chunk_size: int = 65536) -> str:
+    """Computes the SHA256 hex digest of a model artifact file.
+
+    Used for content-addressable storage: identical `.pkl`/`.joblib` files
+    always resolve to the same hash, so the registry can detect duplicate
+    uploads and verify artifact integrity on promotion/rollback.
+    """
+    digest = hashlib.sha256()
+    with open(artifact_path, "rb") as f:
+        for chunk in iter(lambda: f.read(chunk_size), b""):
+            digest.update(chunk)
+    return digest.hexdigest()

--- a/packages/chenai-mlflow/pyproject.toml
+++ b/packages/chenai-mlflow/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "chenai-mlflow"
+version = "0.1.0"
+description = "Python SDK for the ChenAIKit ML model registry and A/B testing framework"
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "MIT" }
+dependencies = [
+    "requests>=2.31.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+    "responses>=0.24",
+]
+
+[tool.setuptools.packages.find]
+include = ["chenai_mlflow*"]


### PR DESCRIPTION
## Summary

Adds MLOps capabilities for versioning, deploying, and A/B testing ML models (credit scoring, fraud detection):

- **Model registry**: Prisma schema (`MLModel`, `MLModelVersion`) with SHA256 content-addressable storage, staging → production promotion behind an approval gate, and lineage metadata (training run, dataset, code commit). `ModelRegistryService` implements `register()` / `promote()` / `rollback()` / `getVersion()`.
- **A/B experiment framework**: `Experiment`, `ExperimentVariant`, `ExperimentAssignment`, `ExperimentEvent` tables. `ExperimentService` implements `createExperiment()` / `assignVariant()` / `trackConversion()` with configurable traffic splits and deterministic sticky bucketing (hash of experiment key + subject id).
- **Statistics**: two-proportion z-test, confidence intervals, minimum-sample-size/power analysis for MDE, and Bonferroni correction for multi-variant experiments (`backend/src/utils/abStatistics.ts`), wired into `ExperimentService.getResults()` with a peek-prevention gate (`readyForDecision`).
- **Model drift detection**: `ModelDriftDetector` records AUC drift checks, alerts when degradation exceeds 3%, and automatically rolls back to the previous production version when degradation exceeds a configurable canary threshold (default 5%).
- **REST API**: `/api/v2/ml-models` — model/version registration, promotion, rollback, drift-check recording, and the full experiment lifecycle (create/start/pause/complete/assign/convert/results).
- **Python SDK**: `chenai-mlflow` package wrapping the REST API for use from training scripts, with local SHA256 hashing of artifacts.
- **Frontend**: `ExperimentDashboard` component — experiment list, variant comparison chart, per-variant statistical indicators (p-value, CI, uplift), peek-prevention banner, and a one-click model rollback dialog.
- **CI/CD**: `.github/workflows/model-deployment.yml` — train → validate → register pipeline; promotion stays a manual, approval-gated step.
- **Docs**: experiment design guide, model deployment runbook, rollback procedures (`docs/ml/`).
- **Example**: `examples/credit-score-ab-test` — credit score v2.0 vs v1.0 with a 90/10 traffic split, end to end.

## Test plan

- [x] `pnpm test` / `pnpm type-check` pass locally (pre-commit hooks ran the full suite on every commit)
- [x] New Prisma migration applies cleanly (`prisma migrate deploy`) on top of the existing schema
- [ ] Manual smoke test of `/api/v2/ml-models` endpoints against a running backend
- [ ] Manual run of `examples/credit-score-ab-test/run_experiment.py`

closes #254

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ML model registration, versioning, promotion, rollback, and drift monitoring.
  * Added A/B experiment management with traffic assignment, conversion tracking, statistical analysis, and power insights.
  * Added an experiment dashboard for monitoring results, controlling experiments, and initiating rollbacks.
  * Added a Python SDK for model and experiment workflows.
  * Added automated model training, validation, and deployment workflows.

* **Documentation**
  * Added guides for experiment design, deployment, rollback procedures, and a credit-scoring A/B testing example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->