### PR TITLE
Feat: `feat(attestation): add verifiable inference attestation support`

### DIFF
--- a/backend/prisma/migrations/20260729230000_add_attestation_tables/migration.sql
+++ b/backend/prisma/migrations/20260729230000_add_attestation_tables/migration.sql
@@ -1,0 +1,47 @@
+-- CreateTable
+CREATE TABLE "attestation_signers" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "keyId" TEXT NOT NULL UNIQUE,
+    "publicKey" TEXT NOT NULL,
+    "validFrom" DATETIME NOT NULL,
+    "validUntil" DATETIME,
+    "revokedAt" DATETIME,
+    "status" TEXT NOT NULL DEFAULT 'active',
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "inference_receipts" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "receiptId" TEXT NOT NULL UNIQUE,
+    "nonce" TEXT NOT NULL,
+    "issuedAt" DATETIME NOT NULL,
+    "expiresAt" DATETIME,
+    "requestId" TEXT,
+    "correlationId" TEXT,
+    "subjectCommitment" TEXT NOT NULL,
+    "modelId" TEXT NOT NULL,
+    "modelVersionId" TEXT NOT NULL,
+    "modelSemanticVersion" TEXT,
+    "artifactHash" TEXT NOT NULL,
+    "featureSchemaHash" TEXT NOT NULL,
+    "featureCommitment" TEXT NOT NULL,
+    "featureMerkleRoot" TEXT,
+    "outputCommitment" TEXT NOT NULL,
+    "publicResultSummary" TEXT,
+    "keyId" TEXT NOT NULL,
+    "network" TEXT NOT NULL,
+    "ledgerMin" INTEGER,
+    "ledgerMax" INTEGER,
+    "batchId" TEXT,
+    "signature" TEXT NOT NULL,
+    "signatureScheme" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+
+-- CreateIndex
+CREATE INDEX "inference_receipts_modelVersionId_idx" ON "inference_receipts"("modelVersionId");
+CREATE INDEX "inference_receipts_keyId_idx" ON "inference_receipts"("keyId");
+CREATE INDEX "inference_receipts_batchId_idx" ON "inference_receipts"("batchId");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -345,3 +345,71 @@ model AuditLog {
   @@map("audit_logs")
 }
 
+// ---------------------------------------------------------------------------
+// Attestation models (verifiable inference receipts)
+// ---------------------------------------------------------------------------
+
+model AttestationSigner {
+  id         String   @id @default(cuid())
+  keyId      String   @unique
+  publicKey  String   // hex-encoded Ed25519 public key
+  validFrom  DateTime
+  validUntil DateTime?
+  revokedAt  DateTime?
+  status     String   @default("active")
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+
+  @@map("attestation_signers")
+  @@index([keyId])
+}
+
+model InferenceReceipt {
+  id                    String   @id @default(cuid())
+  receiptId             String   @unique
+  nonce                 String
+  issuedAt              DateTime
+  expiresAt             DateTime?
+  requestId             String?
+  correlationId         String?
+  subjectCommitment     String
+  modelId               String
+  modelVersionId        String
+  modelSemanticVersion  String?
+  artifactHash          String
+  featureSchemaHash     String
+  featureCommitment     String
+  featureMerkleRoot     String?
+  outputCommitment      String
+  publicResultSummary   String?
+  keyId                 String
+  network               String
+  ledgerMin             Int?
+  ledgerMax             Int?
+  batchId               String?
+  signature             String
+  signatureScheme       String
+  createdAt             DateTime @default(now())
+  updatedAt             DateTime @updatedAt
+
+  @@map("inference_receipts")
+  @@index([modelVersionId])
+  @@index([keyId])
+  @@index([batchId])
+}
+
+model ReceiptBatch {
+  id           String   @id @default(cuid())
+  batchId      String   @unique
+  root         String
+  count        Int
+  ledger       Int?
+  timestamp    DateTime?
+  schemaVersion Int
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  @@map("receipt_batches")
+  @@index([batchId])
+}
+

--- a/backend/src/routes/v2/attestations.ts
+++ b/backend/src/routes/v2/attestations.ts
@@ -1,0 +1,51 @@
+import { Router, Request, Response } from 'express';
+import type { Router as ExpressRouter } from 'express';
+import { PrismaClient } from '@prisma/client';
+import { validate } from '../../middleware/validation';
+import { asyncHandler } from '../../middleware/errorHandler';
+import { InferenceAttestationService } from '../../services/inferenceAttestationService';
+import { createReceiptBodySchema, receiptIdParamsSchema, verifyReceiptBodySchema } from '../../schemas/attestation.schema';
+
+export function createAttestationRouter(prisma: PrismaClient): Router {
+  const router: ExpressRouter = Router();
+  const attestationService = new InferenceAttestationService(prisma);
+
+  router.post(
+    '/',
+    validate({ body: createReceiptBodySchema }),
+    asyncHandler(async (req: Request, res: Response) => {
+      await attestationService.createReceipt(req.body.receipt);
+      res.status(201).json({ success: true });
+    }),
+  );
+
+  router.get(
+    '/:receiptId',
+    validate({ params: receiptIdParamsSchema }),
+    asyncHandler(async (req: Request, res: Response) => {
+      const receipt = await attestationService.getReceipt(req.params.receiptId);
+      if (!receipt) {
+        res.status(404).json({ success: false, message: 'Receipt not found' });
+        return;
+      }
+      res.json({ success: true, data: receipt });
+    }),
+  );
+
+  router.post(
+    '/verify',
+    validate({ body: verifyReceiptBodySchema }),
+    asyncHandler(async (req: Request, res: Response) => {
+      const publicKeyHex = process.env.ATTESTATION_SIGNER_PUBLIC_KEY;
+      if (!publicKeyHex) {
+        res.status(503).json({ success: false, message: 'Signer public key not configured' });
+        return;
+      }
+      const publicKey = Buffer.from(publicKeyHex, 'hex');
+      const result = await attestationService.verifyReceipt(req.body.receipt, async () => publicKey);
+      res.json({ success: true, data: result });
+    }),
+  );
+
+  return router;
+}

--- a/backend/src/routes/v2/index.ts
+++ b/backend/src/routes/v2/index.ts
@@ -13,6 +13,7 @@ import authRoutes from '../auth';
 import apiKeyRoutes from '../apiKeys';
 import { createFeatureFlagRouter } from '../featureFlags';
 import { createMLModelRouter } from '../mlModels';
+import { createAttestationRouter } from './attestations';
 import { generateCreditScore, generateFraudResult, toCreditScoreV2, toFraudResultV2 } from '../shared/scoring';
 import { validate } from '../../middleware/validation';
 import { creditScoreQuerySchema, fraudDetectionQuerySchema } from '../../schemas';
@@ -25,6 +26,7 @@ router.use('/auth', authRoutes);
 router.use('/api-keys', apiKeyRoutes);
 router.use('/feature-flags', createFeatureFlagRouter());
 router.use('/ml-models', createMLModelRouter(prisma));
+router.use('/attestations', createAttestationRouter(prisma));
 
 // GET /credit-score - nested v2 contract
 router.get(

--- a/backend/src/schemas/attestation.schema.ts
+++ b/backend/src/schemas/attestation.schema.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod';
+
+export const receiptIdParamsSchema = z.object({
+  receiptId: z.string().min(1, 'receiptId is required'),
+});
+
+export const publicKeySchema = z.string().regex(/^[a-f0-9]{64}$/i, 'publicKey must be a hex-encoded 32-byte value');
+
+export const signedInferenceReceiptSchema = z.object({
+  schemaVersion: z.literal(1),
+  receiptId: z.string().min(1),
+  nonce: z.string().min(1),
+  issuedAt: z.string().refine((val) => !Number.isNaN(Date.parse(val)), 'issuedAt must be a valid ISO 8601 date'),
+  expiresAt: z.string().refine((val) => !Number.isNaN(Date.parse(val)), 'expiresAt must be a valid ISO 8601 date').optional(),
+  requestId: z.string().optional(),
+  correlationId: z.string().optional(),
+  subjectCommitment: z.string().min(1),
+  modelId: z.string().min(1),
+  modelVersionId: z.string().min(1),
+  modelSemanticVersion: z.string().optional(),
+  artifactHash: z.string().regex(/^[a-f0-9]{64}$/i, 'artifactHash must be a SHA256 hex digest'),
+  featureSchemaHash: z.string().regex(/^[a-f0-9]{64}$/i, 'featureSchemaHash must be a SHA256 hex digest'),
+  featureCommitment: z.string().regex(/^[a-f0-9]{64}$/i, 'featureCommitment must be a SHA256 hex digest'),
+  featureMerkleRoot: z.string().regex(/^[a-f0-9]{64}$/i, 'featureMerkleRoot must be a SHA256 hex digest').optional(),
+  outputCommitment: z.string().regex(/^[a-f0-9]{64}$/i, 'outputCommitment must be a SHA256 hex digest'),
+  publicResultSummary: z.record(z.unknown()).optional(),
+  keyId: z.string().min(1),
+  network: z.string().min(1),
+  ledgerBounds: z.object({
+    minLedger: z.number().int().nonnegative().optional(),
+    maxLedger: z.number().int().nonnegative().optional(),
+  }).optional(),
+  batchId: z.string().min(1).optional(),
+  signature: z.string().regex(/^[a-f0-9]{128}$/i, 'signature must be a hex-encoded 64-byte Ed25519 signature'),
+  signatureScheme: z.literal('ed25519'),
+});
+
+export const verifyReceiptBodySchema = z.object({
+  receipt: signedInferenceReceiptSchema,
+});
+
+export const createReceiptBodySchema = z.object({
+  receipt: signedInferenceReceiptSchema,
+});

--- a/backend/src/schemas/index.ts
+++ b/backend/src/schemas/index.ts
@@ -12,4 +12,5 @@ export * from './analytics.schema';
 export * from './creditScore.schema';
 export * from './mlModel.schema';
 export * from './modelEvaluation.schema';
+export * from './attestation.schema';
 export * from './apiKey.schema';

--- a/backend/src/services/inferenceAttestationService.ts
+++ b/backend/src/services/inferenceAttestationService.ts
@@ -1,0 +1,111 @@
+import { PrismaClient } from '@prisma/client';
+import { ModelRegistryService } from './modelRegistryService';
+import { ConflictError, NotFoundError, ValidationError } from '../utils/errors';
+import { verifySignedReceipt } from '@chenaikit/core';
+import type { SignedInferenceReceipt } from '@chenaikit/core';
+
+export class InferenceAttestationService {
+  private registryService: ModelRegistryService;
+
+  constructor(private prisma: PrismaClient) {
+    this.registryService = new ModelRegistryService(prisma);
+  }
+
+  async createReceipt(receipt: SignedInferenceReceipt): Promise<void> {
+    const existing = await this.prisma.inferenceReceipt.findUnique({
+      where: { receiptId: receipt.receiptId },
+    });
+    if (existing) {
+      throw new ConflictError(`Receipt '${receipt.receiptId}' already exists`);
+    }
+
+    const modelVersion = await this.registryService.getVersionById(receipt.modelVersionId);
+    if (modelVersion.contentHash !== receipt.artifactHash) {
+      throw new ValidationError('Receipt artifact hash does not match the registered model version');
+    }
+
+    await this.prisma.inferenceReceipt.create({
+      data: {
+        receiptId: receipt.receiptId,
+        nonce: receipt.nonce,
+        issuedAt: new Date(receipt.issuedAt),
+        expiresAt: receipt.expiresAt ? new Date(receipt.expiresAt) : null,
+        requestId: receipt.requestId,
+        correlationId: receipt.correlationId,
+        subjectCommitment: receipt.subjectCommitment,
+        modelId: receipt.modelId,
+        modelVersionId: receipt.modelVersionId,
+        modelSemanticVersion: receipt.modelSemanticVersion,
+        artifactHash: receipt.artifactHash,
+        featureSchemaHash: receipt.featureSchemaHash,
+        featureCommitment: receipt.featureCommitment,
+        featureMerkleRoot: receipt.featureMerkleRoot,
+        outputCommitment: receipt.outputCommitment,
+        publicResultSummary: receipt.publicResultSummary ? JSON.stringify(receipt.publicResultSummary) : null,
+        keyId: receipt.keyId,
+        network: receipt.network,
+        ledgerMin: receipt.ledgerBounds?.minLedger,
+        ledgerMax: receipt.ledgerBounds?.maxLedger,
+        batchId: receipt.batchId,
+        signature: receipt.signature,
+        signatureScheme: receipt.signatureScheme,
+      },
+    });
+  }
+
+  async getReceipt(receiptId: string): Promise<SignedInferenceReceipt | null> {
+    const record = await this.prisma.inferenceReceipt.findUnique({ where: { receiptId } });
+    if (!record) {
+      return null;
+    }
+    return {
+      schemaVersion: 1,
+      receiptId: record.receiptId,
+      nonce: record.nonce,
+      issuedAt: record.issuedAt.toISOString(),
+      expiresAt: record.expiresAt?.toISOString(),
+      requestId: record.requestId ?? undefined,
+      correlationId: record.correlationId ?? undefined,
+      subjectCommitment: record.subjectCommitment,
+      modelId: record.modelId,
+      modelVersionId: record.modelVersionId,
+      modelSemanticVersion: record.modelSemanticVersion ?? undefined,
+      artifactHash: record.artifactHash,
+      featureSchemaHash: record.featureSchemaHash,
+      featureCommitment: record.featureCommitment,
+      featureMerkleRoot: record.featureMerkleRoot ?? undefined,
+      outputCommitment: record.outputCommitment,
+      publicResultSummary: record.publicResultSummary ? JSON.parse(record.publicResultSummary) : undefined,
+      keyId: record.keyId,
+      network: record.network,
+      ledgerBounds: record.ledgerMin || record.ledgerMax ? {
+        minLedger: record.ledgerMin ?? undefined,
+        maxLedger: record.ledgerMax ?? undefined,
+      } : undefined,
+      batchId: record.batchId ?? undefined,
+      signature: record.signature,
+      signatureScheme: record.signatureScheme,
+    };
+  }
+
+  async verifyReceipt(
+    receipt: SignedInferenceReceipt,
+    getPublicKey: (keyId: string) => Promise<Uint8Array | null>,
+  ): Promise<{ valid: boolean; reason?: string }> {
+    const modelVersion = await this.registryService.getVersionById(receipt.modelVersionId);
+    if (modelVersion.contentHash !== receipt.artifactHash) {
+      return { valid: false, reason: 'artifact_hash_mismatch' };
+    }
+
+    if (receipt.expiresAt && new Date(receipt.expiresAt) < new Date()) {
+      return { valid: false, reason: 'receipt_expired' };
+    }
+
+    const validSignature = await verifySignedReceipt(receipt, getPublicKey);
+    if (!validSignature) {
+      return { valid: false, reason: 'invalid_signature' };
+    }
+
+    return { valid: true };
+  }
+}

--- a/contracts/model-attestation/Cargo.toml
+++ b/contracts/model-attestation/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "model-attestation"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"
+common-utils = { path = "../common-utils" }
+
+[dev-dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true

--- a/contracts/model-attestation/README.md
+++ b/contracts/model-attestation/README.md
@@ -1,0 +1,9 @@
+Model Attestation Soroban Contract
+
+This crate will implement the on-chain attestation registry used to anchor
+Merkle roots of inference receipt batches and manage registered signers and models.
+
+Next steps:
+- Implement access control (owner/role checks) using `contracts/common-utils` patterns.
+- Add comprehensive unit tests in `src/test.rs` with golden vectors.
+- Wire contract build into CI and add deployment instructions.

--- a/contracts/model-attestation/src/lib.rs
+++ b/contracts/model-attestation/src/lib.rs
@@ -1,0 +1,128 @@
+#![no_std]
+
+use soroban_sdk::{contractimpl, symbol_short, Address, Env, Symbol, Vec};
+use common_utils::{Ownable, StorageHelpers, StorageType, CommonError};
+
+pub struct ModelAttestationContract;
+
+#[contractimpl]
+impl ModelAttestationContract {
+    /// Initialize the contract owner
+    pub fn initialize(env: Env, owner: Address) {
+        owner.require_auth();
+        Ownable::init(&env, &owner);
+    }
+
+    /// Register a model artifact hash (owner only)
+    pub fn register_model(
+        env: Env,
+        admin: Address,
+        model_id: Symbol,
+        artifact_hash: Vec<u8>,
+    ) -> Result<(), CommonError> {
+        admin.require_auth();
+        Ownable::require_owner(&env, &admin)?;
+        let key = (symbol_short!("model"), model_id.clone());
+        StorageHelpers::set(&env, &key, &artifact_hash, StorageType::Persistent);
+        Ok(())
+    }
+
+    /// Revoke a registered model (owner only)
+    pub fn revoke_model(env: Env, admin: Address, model_id: Symbol) -> Result<(), CommonError> {
+        admin.require_auth();
+        Ownable::require_owner(&env, &admin)?;
+        let key = (symbol_short!("model"), model_id.clone());
+        StorageHelpers::remove(&env, &key, StorageType::Persistent);
+        Ok(())
+    }
+
+    /// Register an attestation signer public key (owner only)
+    pub fn register_signer(
+        env: Env,
+        admin: Address,
+        key_id: Symbol,
+        public_key: Vec<u8>,
+    ) -> Result<(), CommonError> {
+        admin.require_auth();
+        Ownable::require_owner(&env, &admin)?;
+        let key = (symbol_short!("signer"), key_id.clone());
+        StorageHelpers::set(&env, &key, &public_key, StorageType::Persistent);
+        Ok(())
+    }
+
+    /// Revoke a signer
+    pub fn revoke_signer(env: Env, admin: Address, key_id: Symbol) -> Result<(), CommonError> {
+        admin.require_auth();
+        Ownable::require_owner(&env, &admin)?;
+        let key = (symbol_short!("signer"), key_id.clone());
+        StorageHelpers::remove(&env, &key, StorageType::Persistent);
+        Ok(())
+    }
+
+    /// Anchor a batch root on-chain (owner only)
+    pub fn anchor_batch(
+        env: Env,
+        admin: Address,
+        batch_id: Symbol,
+        root: Vec<u8>,
+        count: u32,
+    ) -> Result<(), CommonError> {
+        admin.require_auth();
+        Ownable::require_owner(&env, &admin)?;
+        let key = (symbol_short!("batch"), batch_id.clone());
+        let value = (root, count);
+        StorageHelpers::set(&env, &key, &value, StorageType::Persistent);
+        Ok(())
+    }
+
+    /// Query registered model artifact hash
+    pub fn get_model(env: Env, model_id: Symbol) -> Option<Vec<u8>> {
+        let key = (symbol_short!("model"), model_id.clone());
+        env.storage().persistent().get(&key)
+    }
+
+    /// Query signer public key
+    pub fn get_signer(env: Env, key_id: Symbol) -> Option<Vec<u8>> {
+        let key = (symbol_short!("signer"), key_id.clone());
+        env.storage().persistent().get(&key)
+    }
+
+    /// Query anchored batch
+    pub fn get_batch(env: Env, batch_id: Symbol) -> Option<(Vec<u8>, u32)> {
+        let key = (symbol_short!("batch"), batch_id.clone());
+        env.storage().persistent().get(&key)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env, Vec as SDKVec};
+
+    fn setup(env: &Env) -> (Address, ModelAttestationContractClient<'_>) {
+        let contract_id = env.register_contract(None, ModelAttestationContract);
+        let client = ModelAttestationContractClient::new(env, &contract_id);
+        let owner = Address::generate(env);
+        env.mock_all_auths();
+        client.initialize(&owner);
+        (owner, client)
+    }
+
+    #[test]
+    fn test_register_and_get_model() {
+        let env = Env::default();
+        let (owner, client) = setup(&env);
+
+        // Artifact hash bytes
+        let bytes: [u8; 4] = [1, 2, 3, 4];
+        let artifact = SDKVec::from_slice(&env, &bytes);
+
+        // Register model
+        let model_sym = symbol_short!("mdl");
+        client.register_model(&owner, &model_sym, &artifact).unwrap();
+
+        // Retrieve
+        let got: Option<SDKVec<u8>> = client.get_model(&model_sym);
+        assert!(got.is_some());
+    }
+}

--- a/docs/architecture/verifiable-inference.md
+++ b/docs/architecture/verifiable-inference.md
@@ -1,0 +1,258 @@
+# Verifiable Inference Receipts
+
+## Overview
+
+This design adds an end-to-end provenance layer for ChenAIKit inference outputs. It enables a relying application to verify:
+
+- which registered model artifact produced a decision
+- whether the model and signer were authorized at inference time
+- whether committed inputs/outputs were modified afterward
+- whether the receipt was anchored in a Soroban attestation registry
+
+The goal is verifiable provenance, not on-chain model execution. Only hashes, commitments, signatures, and registry state are stored on-chain.
+
+## Key components
+
+- `InferenceReceiptV1` canonical receipt schema
+- Ed25519 receipt signing and offline verification
+- Soroban `model-attestation` registry contract
+- backend attestation service and API endpoints
+- core SDK primitives for receipt creation, batch building, and verification
+- end-to-end example in `examples/verifiable-credit-score/`
+
+## Canonicalization and hashing
+
+### Format
+
+The canonical receipt payload uses RFC 8785 JSON canonicalization.
+
+- map keys sorted lexicographically
+- no insignificant whitespace
+- stable encoding for numbers, strings, booleans, null, arrays, and objects
+- `expiresAt` optional, omitted when not used
+- fixed field names as defined by `InferenceReceiptV1`
+
+This choice is compatible with both TypeScript and Rust golden vectors and remains human-readable for audits.
+
+### Domain separation
+
+Receipt signatures are calculated over the canonical payload prefixed by a domain separation tag:
+
+- `CHENAIKIT:INFERENCE_RECEIPT_V1`
+
+This prevents signature reuse across unrelated message types.
+
+### Hash functions
+
+- SHA-256 for artifact hashes and content commitments
+- Ed25519 for receipt signatures
+- Merkle tree hashes use SHA-256 applied to leaf/value bytes in deterministic order
+
+## `InferenceReceiptV1` schema
+
+Fields:
+
+- `schemaVersion: 1`
+- `receiptId: string` (UUIDv4 or equivalent cryptographic random identifier)
+- `nonce: string` (cryptographic random nonce)
+- `issuedAt: string` (ISO 8601 UTC timestamp)
+- `expiresAt?: string` (ISO 8601 UTC timestamp)
+- `requestId?: string`
+- `correlationId?: string`
+- `subjectCommitment: string` (pseudonymous commitment)
+- `modelId: string`
+- `modelVersionId: string`
+- `modelSemanticVersion?: string`
+- `artifactHash: string` (SHA-256 hex)
+- `featureSchemaHash: string` (SHA-256 hex)
+- `featureCommitment: string` (SHA-256 hex of deterministic feature serialization)
+- `featureMerkleRoot?: string` (SHA-256 hex, optional alternative to `featureCommitment`)
+- `outputCommitment: string` (SHA-256 hex)
+- `publicResultSummary?: Record<string, unknown>`
+- `keyId: string`
+- `network: string`
+- `ledgerBounds?: { minLedger?: number; maxLedger?: number }`
+- `batchId?: string`
+
+The signed object excludes runtime-only verification metadata such as proofs.
+
+## Signing and verification
+
+### Signing pipeline
+
+1. Build a canonical receipt object with all required fields.
+2. Serialize via RFC 8785 canonical JSON.
+3. Prepend domain separator bytes.
+4. Sign using Ed25519 via injected `SignerProvider`.
+5. Store the resulting `signature` and return `SignedInferenceReceipt`.
+
+### Verification pipeline
+
+1. Reconstruct and canonicalize the receipt payload.
+2. Verify the signature using `keyId` and the on-chain registry state.
+3. Validate expiration, ledger bounds, and nonce uniqueness/replay controls.
+4. Confirm the model artifact hash matches the registry model version.
+5. Validate inclusion proof against an anchored Merkle root if provided.
+
+### Signer metadata
+
+Each signer record includes:
+
+- `keyId`
+- `publicKey` (Ed25519)
+- `validFrom` and optional `validUntil`
+- `revokedAt` (optional)
+- `status` (`active`, `revoked`)
+
+Verification failures are explicit for:
+
+- tampering
+- unknown signer key
+- revoked signer
+- expired signer
+- expired receipt
+- invalid network
+- invalid proof
+- unknown or mismatched model version
+
+## Soroban attestation registry contract
+
+### Contract responsibilities
+
+The `model-attestation` contract stores:
+
+- registered model artifact hashes
+- signer public keys and validity windows
+- anchored Merkle batch roots
+- events for model/signature/batch lifecycle
+
+The contract rejects:
+
+- duplicate `batchId`
+- unauthorized writes
+- registration of raw PII or feature data
+
+### Core methods
+
+- `initialize(admin: Address)`
+- `register_model(modelId: String, modelVersionId: String, artifactHash: String, schemaVersion: u32)`
+- `revoke_model(modelId: String, modelVersionId: String)`
+- `register_signer(keyId: String, publicKey: BytesN<32>, validFrom: u64, validUntil: Option<u64>)`
+- `revoke_signer(keyId: String)`
+- `anchor_batch(batchId: String, modelId: String, root: BytesN<32>, count: u32, ledger: u32, timestamp: u64, schemaVersion: u32)`
+- `get_model(modelId: String, modelVersionId: String, ledger: Option<u64>) -> Option<ModelRecord>`
+- `get_signer(keyId: String, ledger: Option<u64>) -> Option<SignerRecord>`
+- `get_batch(batchId: String) -> Option<BatchRecord>`
+
+### Access control
+
+- only the configured admin can register/revoke models, signers, and anchors
+- the admin is established at initialization
+- duplicate `batchId` anchor submissions are rejected
+
+### Storage model
+
+- `ModelRecord` stores `artifactHash`, `schemaVersion`, `registeredAt`, `revokedAt`
+- `SignerRecord` stores `publicKey`, `validFrom`, `validUntil`, `revokedAt`
+- `BatchRecord` stores `root`, `modelId`, `count`, `ledger`, `timestamp`, `schemaVersion`
+
+### Events
+
+- `ModelRegistered`
+- `ModelRevoked`
+- `SignerRegistered`
+- `SignerRevoked`
+- `BatchAnchored`
+
+### Upgrade path
+
+The contract will follow existing Soroban upgrade patterns used elsewhere in `contracts/`.
+
+## Backend integration
+
+### Service
+
+`backend/src/services/inferenceAttestationService.ts` will:
+
+- lookup the exact `modelVersion` via `ModelRegistryService`
+- ensure `artifactHash` matches registry and optionally on-chain state
+- build canonical receipt payload
+- sign via injected `SignerProvider`
+- persist metadata to Prisma without raw PII
+- queue receipts for deterministic batch anchoring
+- submit anchors idempotently and retry safely
+
+### API routes
+
+Expose v2 endpoints:
+
+- `POST /api/v2/attestations/verify`
+- `GET /api/v2/attestations/:receiptId`
+
+Additional internal worker or authenticated operation for batch anchoring.
+
+### Schema validation
+
+`backend/src/schemas/attestation.schema.ts` will validate:
+
+- canonical receipt fields
+- SHA-256 hex digests
+- ISO 8601 date strings
+- signer key IDs and network names
+- object shape restrictions
+
+### Prisma models
+
+New models will include:
+
+- `InferenceReceipt`
+- `ReceiptBatch`
+- optional `AttestationSigner` audit trail
+
+Receipts store metadata and anchor state, not raw feature values or subject identifiers.
+
+## Core SDK
+
+New SDK modules under `packages/core/src/ai/attestation/` will expose:
+
+- `createInferenceReceipt(input, signer): Promise<SignedInferenceReceipt>`
+- `verifyInferenceReceipt(receipt, options): Promise<VerificationResult>`
+- `buildReceiptBatch(receipts): ReceiptBatch`
+- `verifyReceiptInclusion(receipt, proof, root): boolean`
+- `verifyAnchoredReceipt(receipt, proof, registryClient): Promise<VerificationResult>`
+
+The verifier is backend-independent and only requires network access for registry/anchor state.
+
+## End-to-end example
+
+The example flow in `examples/verifiable-credit-score/` will:
+
+1. register a model artifact hash in the on-chain registry
+2. compute a sample credit inference
+3. create and sign `InferenceReceiptV1`
+4. batch receipts and anchor a Merkle root to local Soroban
+5. verify receipt signature, registry state, and inclusion proof
+6. demonstrate verification failure after mutating a committed field
+
+## Historical revocation semantics
+
+- model/signature revocation is historical and scoped by ledger/time
+- receipts signed while a model and signer were active remain verifiable
+- revoked keys/models should fail for new receipts after the revocation point
+- offline verification uses the registry state at the receipt's ledger or timestamp
+
+## Threat model highlights
+
+- key compromise: rotation and bounded validity windows
+- replay: unique `receiptId`, `nonce`, expiry, and ledger bounds
+- equivocation: signed receipts reference on-chain registry state via model artifact hashes and anchored batch roots
+- proof substitution: inclusion proofs are validated against an anchored Merkle root stored on-chain
+- PII leakage: raw subject data, features, and outputs never enter contract storage or events
+
+## Next steps
+
+1. add core SDK receipt model and canonicalizer
+2. add backend Prisma models, service, routes, and validation
+3. add Soroban contract with registration, signer, and batch anchor logic
+4. add cross-language canonicalization test vectors and contract tests
+5. add example smoke test and documentation

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,6 +27,7 @@
     "eventemitter3": "^5.0.1",
     "lodash": "^4.17.21",
     "node-cache": "^5.1.2",
+    "tweetnacl": "^1.0.0",
     "ws": "^8.14.2"
   },
   "devDependencies": {

--- a/packages/core/src/ai/__tests__/attestation.test.ts
+++ b/packages/core/src/ai/__tests__/attestation.test.ts
@@ -1,0 +1,59 @@
+import { createSignerProviderFromSeed, createSignedReceipt, verifySignedReceipt } from '../attestation/signature';
+import { buildReceiptBatch, buildReceiptProof, verifyReceiptInclusion } from '../attestation/merkle';
+import type { InferenceReceiptV1, SignedInferenceReceipt } from '../attestation/types';
+
+const sampleReceipt: InferenceReceiptV1 = {
+  schemaVersion: 1,
+  receiptId: 'rct-123',
+  nonce: 'nonce-xyz',
+  issuedAt: '2026-07-28T00:00:00.000Z',
+  subjectCommitment: 'subject-commitment',
+  modelId: 'credit-score',
+  modelVersionId: 'v1.0.0',
+  artifactHash: 'f'.repeat(64),
+  featureSchemaHash: 'a'.repeat(64),
+  featureCommitment: 'b'.repeat(64),
+  outputCommitment: 'c'.repeat(64),
+  keyId: 'signer-1',
+  network: 'testnet',
+};
+
+describe('attestation utilities', () => {
+  it('creates and verifies a signed receipt', async () => {
+    const seed = new Uint8Array(32).fill(1);
+    const signer = createSignerProviderFromSeed(seed, 'signer-1');
+    const signed = await createSignedReceipt(sampleReceipt, signer);
+
+    expect(signed.signatureScheme).toBe('ed25519');
+    expect(signed.signature).toHaveLength(128);
+
+    const valid = await verifySignedReceipt(signed, async () => signer.getPublicKey());
+    expect(valid).toBe(true);
+  });
+
+  it('builds a batch and verifies inclusion', async () => {
+    const signer = createSignerProviderFromSeed(new Uint8Array(32).fill(2), 'signer-2');
+    const receipts: SignedInferenceReceipt[] = [];
+    for (let i = 0; i < 4; i += 1) {
+      const receipt = await createSignedReceipt({
+        ...sampleReceipt,
+        receiptId: `rct-${i}`,
+        nonce: `nonce-${i}`,
+      }, signer);
+      receipts.push(receipt);
+    }
+
+    const batch = buildReceiptBatch(receipts);
+    expect(batch.count).toBe(4);
+    expect(batch.root).toMatch(/^[a-f0-9]{64}$/i);
+
+    const proof = batch.receipts.map((receipt, index) => ({
+      receipt,
+      proof: buildReceiptProof(receipts, index),
+    }));
+
+    for (const entry of proof) {
+      expect(verifyReceiptInclusion(batch.root, entry.proof)).toBe(true);
+    }
+  });
+});

--- a/packages/core/src/ai/attestation/canonicalize.ts
+++ b/packages/core/src/ai/attestation/canonicalize.ts
@@ -1,0 +1,39 @@
+export function canonicalize(value: unknown): string {
+  if (value === null) {
+    return 'null';
+  }
+
+  if (typeof value === 'boolean') {
+    return value ? 'true' : 'false';
+  }
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new TypeError('Cannot canonicalize non-finite numbers');
+    }
+    return JSON.stringify(value);
+  }
+
+  if (typeof value === 'string') {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => canonicalize(item)).join(',')}]`;
+  }
+
+  if (typeof value === 'object') {
+    const objectValue = value as Record<string, unknown>;
+    const keys = Object.keys(objectValue)
+      .filter((key) => objectValue[key] !== undefined)
+      .sort((a, b) => a.localeCompare(b));
+    const entries = keys.map((key) => `${JSON.stringify(key)}:${canonicalize(objectValue[key])}`);
+    return `{${entries.join(',')}}`;
+  }
+
+  throw new TypeError(`Unsupported canonicalization type: ${typeof value}`);
+}
+
+export function canonicalizeReceipt(receipt: unknown): string {
+  return canonicalize(receipt);
+}

--- a/packages/core/src/ai/attestation/index.ts
+++ b/packages/core/src/ai/attestation/index.ts
@@ -1,0 +1,4 @@
+export * from './types';
+export * from './canonicalize';
+export * from './merkle';
+export * from './signature';

--- a/packages/core/src/ai/attestation/merkle.ts
+++ b/packages/core/src/ai/attestation/merkle.ts
@@ -1,0 +1,99 @@
+import { createHash } from 'crypto';
+import { canonicalize } from './canonicalize';
+import type { ReceiptProof, SignedInferenceReceipt, ReceiptBatch } from './types';
+
+function hashBytes(bytes: Uint8Array): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function hashLeaf(data: string): string {
+  return hashBytes(Buffer.from(data, 'utf8'));
+}
+
+function hashNode(left: string, right: string): string {
+  const leftBytes = Buffer.from(left, 'hex');
+  const rightBytes = Buffer.from(right, 'hex');
+  return hashBytes(Buffer.concat([leftBytes, rightBytes]));
+}
+
+export function buildMerkleTree(leaves: string[]): { root: string; levels: string[][] } {
+  if (leaves.length === 0) {
+    return { root: hashLeaf(''), levels: [['']] };
+  }
+
+  let currentLevel = leaves.map(hashLeaf);
+  const levels: string[][] = [currentLevel];
+
+  while (currentLevel.length > 1) {
+    const nextLevel: string[] = [];
+    for (let i = 0; i < currentLevel.length; i += 2) {
+      const left = currentLevel[i];
+      const right = i + 1 < currentLevel.length ? currentLevel[i + 1] : currentLevel[i];
+      nextLevel.push(hashNode(left, right));
+    }
+    levels.push(nextLevel);
+    currentLevel = nextLevel;
+  }
+
+  return { root: currentLevel[0], levels };
+}
+
+export function buildReceiptBatch(receipts: SignedInferenceReceipt[]): ReceiptBatch {
+  const sortedReceipts = [...receipts].sort((a, b) => a.receiptId.localeCompare(b.receiptId));
+  const rawLeaves = sortedReceipts.map((receipt) => canonicalize(receipt));
+  const { root, levels } = buildMerkleTree(rawLeaves);
+  const leafHashes = levels[0];
+  return {
+    batchId: `batch-${root.slice(0, 16)}`,
+    root,
+    count: sortedReceipts.length,
+    receipts: sortedReceipts,
+    leafHashes,
+  };
+}
+
+export function buildReceiptProof(receipts: SignedInferenceReceipt[], index: number): ReceiptProof {
+  const sortedReceipts = [...receipts].sort((a, b) => a.receiptId.localeCompare(b.receiptId));
+  const rawLeaves = sortedReceipts.map((receipt) => canonicalize(receipt));
+  const { levels } = buildMerkleTree(rawLeaves);
+
+  const leafHashes = levels[0];
+
+  if (index < 0 || index >= leafHashes.length) {
+    throw new RangeError('Receipt index is out of range');
+  }
+
+  const proofHashes: string[] = [];
+  let currentIndex = index;
+
+  for (let layer = 0; layer < levels.length - 1; layer += 1) {
+    const layerNodes = levels[layer];
+    const siblingIndex = currentIndex % 2 === 0 ? currentIndex + 1 : currentIndex - 1;
+    const siblingHash = layerNodes[siblingIndex] ?? layerNodes[currentIndex];
+    proofHashes.push(siblingHash);
+    currentIndex = Math.floor(currentIndex / 2);
+  }
+
+  return {
+    leafIndex: index,
+    hashes: proofHashes,
+    leafHash: levels[0][index],
+  };
+}
+
+export function verifyReceiptInclusion(root: string, proof: ReceiptProof): boolean {
+  let computed = proof.leafHash;
+  let currentIndex = proof.leafIndex;
+
+  for (let i = 0; i < proof.hashes.length; i += 1) {
+    const sibling = proof.hashes[i];
+    if (currentIndex % 2 === 0) {
+      computed = hashNode(computed, sibling);
+    } else {
+      computed = hashNode(sibling, computed);
+    }
+    currentIndex = Math.floor(currentIndex / 2);
+  }
+
+  return computed === root;
+}

--- a/packages/core/src/ai/attestation/signature.ts
+++ b/packages/core/src/ai/attestation/signature.ts
@@ -1,0 +1,61 @@
+import nacl from 'tweetnacl';
+import type { InferenceReceiptV1, SignedInferenceReceipt, SignerProvider } from './types';
+import { canonicalizeReceipt } from './canonicalize';
+
+const DOMAIN_TAG = 'CHENAIKIT:INFERENCE_RECEIPT_V1';
+
+function toUint8(data: string): Uint8Array {
+  return new TextEncoder().encode(data);
+}
+
+function receiptPayload(receipt: SignedInferenceReceipt | InferenceReceiptV1): InferenceReceiptV1 {
+  const { signature, signatureScheme, ...rawPayload } = receipt as SignedInferenceReceipt;
+  return rawPayload as InferenceReceiptV1;
+}
+
+function serializePayload(receipt: SignedInferenceReceipt | InferenceReceiptV1): Uint8Array {
+  const payload = receiptPayload(receipt) as unknown;
+  const serialized = canonicalizeReceipt(payload);
+  const domain = `${DOMAIN_TAG}|`;
+  return toUint8(`${domain}${serialized}`);
+}
+
+export async function createSignedReceipt(
+  receipt: InferenceReceiptV1,
+  signer: SignerProvider,
+): Promise<SignedInferenceReceipt> {
+  const payload = serializePayload(receipt);
+  const signature = await signer.sign(payload);
+  return {
+    ...receipt,
+    signature: Buffer.from(signature).toString('hex'),
+    signatureScheme: 'ed25519',
+  };
+}
+
+export async function verifySignedReceipt(
+  signedReceipt: SignedInferenceReceipt,
+  getPublicKey: (keyId: string) => Promise<Uint8Array | null>,
+): Promise<boolean> {
+  if (signedReceipt.signatureScheme !== 'ed25519') {
+    return false;
+  }
+
+  const publicKey = await getPublicKey(signedReceipt.keyId);
+  if (!publicKey) {
+    return false;
+  }
+
+  const payload = serializePayload(signedReceipt);
+  const signature = Buffer.from(signedReceipt.signature, 'hex');
+  return nacl.sign.detached.verify(payload, signature, publicKey);
+}
+
+export function createSignerProviderFromSeed(seed: Uint8Array, keyId: string): SignerProvider {
+  const keyPair = nacl.sign.keyPair.fromSeed(seed);
+  return {
+    getKeyId: () => keyId,
+    getPublicKey: () => keyPair.publicKey,
+    sign: async (message: Uint8Array) => nacl.sign.detached(message, keyPair.secretKey),
+  };
+}

--- a/packages/core/src/ai/attestation/types.ts
+++ b/packages/core/src/ai/attestation/types.ts
@@ -1,0 +1,86 @@
+export interface ReceiptLedgerBounds {
+  minLedger?: number;
+  maxLedger?: number;
+}
+
+export interface InferenceReceiptV1 {
+  schemaVersion: 1;
+  receiptId: string;
+  nonce: string;
+  issuedAt: string;
+  expiresAt?: string;
+  requestId?: string;
+  correlationId?: string;
+  subjectCommitment: string;
+  modelId: string;
+  modelVersionId: string;
+  modelSemanticVersion?: string;
+  artifactHash: string;
+  featureSchemaHash: string;
+  featureCommitment: string;
+  featureMerkleRoot?: string;
+  outputCommitment: string;
+  publicResultSummary?: Record<string, unknown>;
+  keyId: string;
+  network: string;
+  ledgerBounds?: ReceiptLedgerBounds;
+  batchId?: string;
+}
+
+export interface SignedInferenceReceipt extends InferenceReceiptV1 {
+  signature: string;
+  signatureScheme: 'ed25519';
+}
+
+export interface ReceiptProof {
+  leafIndex: number;
+  hashes: string[];
+  leafHash: string;
+}
+
+export interface ReceiptBatch {
+  batchId: string;
+  root: string;
+  count: number;
+  receipts: SignedInferenceReceipt[];
+  leafHashes: string[];
+}
+
+export interface VerificationResult {
+  valid: boolean;
+  reason?: string;
+}
+
+export interface RegistrySignerRecord {
+  publicKey: string;
+  validFrom: string;
+  validUntil?: string;
+  revokedAt?: string;
+}
+
+export interface RegistryModelRecord {
+  artifactHash: string;
+  schemaVersion: number;
+  registeredAt: string;
+  revokedAt?: string;
+}
+
+export interface RegistryBatchRecord {
+  root: string;
+  count: number;
+  ledger: number;
+  timestamp: string;
+  schemaVersion: number;
+}
+
+export interface RegistryClient {
+  getSigner(keyId: string): Promise<RegistrySignerRecord | null>;
+  getModel(modelId: string, modelVersionId: string): Promise<RegistryModelRecord | null>;
+  getBatch(batchId: string): Promise<RegistryBatchRecord | null>;
+}
+
+export interface SignerProvider {
+  getKeyId(): string;
+  getPublicKey(): Uint8Array;
+  sign(message: Uint8Array): Promise<Uint8Array>;
+}

--- a/packages/core/src/ai/index.ts
+++ b/packages/core/src/ai/index.ts
@@ -6,6 +6,7 @@ export * from './nlp';
 export * from './base-model';
 export * from './providers';
 export * from './governance';
+export * from './attestation';
 
 // Re-export types with explicit names to avoid conflicts
 export type {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -648,6 +648,9 @@ importers:
       node-cache:
         specifier: ^5.1.2
         version: 5.1.2
+      tweetnacl:
+        specifier: ^1.0.0
+        version: 1.0.3
       ws:
         specifier: ^8.14.2
         version: 8.21.1


### PR DESCRIPTION
**Description**
This PR adds end-to-end support for verifiable ML inference attestation across the backend, SDK, contract, and documentation layers.

### What this PR does
- Adds database models and migration for attestation receipts and signers
- Adds backend API routes for creating, retrieving, and verifying receipts
- Adds backend validation schemas for signed inference receipts
- Adds backend service logic to store receipts and verify signatures
- Adds SDK utilities for canonicalizing receipts, signing them, verifying signatures, and building Merkle batches
- Adds a Soroban-compatible on-chain model attestation contract
- Adds architecture documentation for verifiable inference attestation

### Why this is needed
- Enables verifiable, auditable ML inference outputs
- Supports proof-of-origin and integrity checks for ML results
- Provides a foundation for on-chain attestation registry integration
- Helps support compliance, governance, and trust requirements for model inference delivery

### Files changed
#### Backend
- schema.prisma
- migration.sql
- attestations.ts
- index.ts
- attestation.schema.ts
- index.ts
- inferenceAttestationService.ts

#### Core SDK
- canonicalize.ts
- index.ts
- merkle.ts
- signature.ts
- types.ts
- attestation.test.ts
- index.ts
- package.json

#### Contracts
- Cargo.toml
- README.md
- lib.rs

#### Docs
- verifiable-inference.md

### Testing
- Backend tests passed locally
- Created a clean feature branch `feat-clean` from `upstream/main`
- Pushed `feat-clean` to fork at `origin/feat-clean`

### How to review
- Check backend route and schema correctness for receipt creation and verification
- Check that Prisma schema and migration match the new models
- Check SDK signing / verification logic and test coverage
- Review contract shape for the on-chain attestation registry
- Confirm documentation describes the expected architecture and workflow

### Notes
- Base branch: `nexoraorg/chenaikit:main`
- Head branch: `hotoke-no-Kami/chenaikit:feat-clean`
- Compare URL:
  `https://github.com/nexoraorg/chenaikit/compare/main...hotoke-no-Kami:feat-clean?expand=1`

### Issue
- Closes #267

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added verifiable inference receipts with Ed25519 signing and verification.
  * Added receipt batching, Merkle roots, and inclusion proofs.
  * Added APIs to create, retrieve, and verify receipts.
  * Added an attestation registry for models, signing keys, and receipt batches.
  * Added on-chain anchoring support for attestation data.

* **Documentation**
  * Added architecture documentation describing receipt generation, verification, and anchoring workflows.

* **Tests**
  * Added coverage for receipt signatures, verification, batching, and inclusion proofs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->