### PR TITLE
fix(deploy): bump pnpm to v9.15.9 for Node 24 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.1.0",
   "description": "chenaikit monorepo — contracts / backend / frontend / shared packages",
-  "packageManager": "pnpm@9.0.0",
+  "packageManager": "pnpm@9.15.9",
   "scripts": {
     "build": "pnpm -r --filter=./apps/* --filter=./packages/* run build",
     "backend:build": "pnpm --filter ./apps/backend run build",


### PR DESCRIPTION
pnpm 9.0.0 has known ERR_INVALID_THIS bug with URLSearchParams on newer Node.js, causing ERR_PNPM_META_FETCH_FAIL during install.