### PR TITLE
feat(frontend): add accessible keyboard navigation to top nav (Closes #297)

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -8,9 +8,14 @@ export function App() {
 
   return (
     <>
+      <a href="#main-content" className="skip-link">
+        Skip to content
+      </a>
       <div className="ledger-margin" />
       <TopNav view={view} onChange={setView} />
-      {view === "landing" ? <Landing /> : <Dashboard />}
+      <div id="main-content">
+        {view === "landing" ? <Landing /> : <Dashboard />}
+      </div>
     </>
   );
 }

--- a/apps/frontend/src/components/TopNav.tsx
+++ b/apps/frontend/src/components/TopNav.tsx
@@ -8,22 +8,24 @@ export function TopNav({
   onChange: (v: View) => void;
 }) {
   return (
-    <nav className="topnav">
+    <nav className="topnav" aria-label="Main navigation">
       <div className="topnav-inner">
         <div className="brand">
-          <span className="dot" />
+          <span className="dot" aria-hidden="true" />
           chenaikit
         </div>
         <div className="navlinks">
           <button
             className={view === "landing" ? "active" : ""}
             onClick={() => onChange("landing")}
+            aria-current={view === "landing" ? "page" : undefined}
           >
             Overview
           </button>
           <button
             className={view === "dashboard" ? "active" : ""}
             onClick={() => onChange("dashboard")}
+            aria-current={view === "dashboard" ? "page" : undefined}
           >
             Dashboard
           </button>

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -26,6 +26,18 @@
   }
   ::selection{background:var(--stamp-red); color:var(--paper);}
   a{color:inherit;}
+  :focus-visible{outline:2px solid var(--stamp-blue); outline-offset:2px;}
+  :focus:not(:focus-visible){outline:none;}
+
+  /* SKIP-TO-CONTENT */
+  .skip-link{
+    position:absolute; top:-100px; left:8px; z-index:100;
+    background:var(--stamp-blue); color:var(--paper);
+    font-family:var(--mono-data); font-size:13px; font-weight:600;
+    padding:10px 16px; border-radius:0 0 3px 3px;
+    text-decoration:none; transition:top 0.15s;
+  }
+  .skip-link:focus{top:0;}
 
   .ledger-margin{
     position:fixed;
@@ -74,6 +86,12 @@
   }
   .navlinks button.active{color:var(--ink); border-color:var(--stamp-red);}
   .navlinks button:hover{color:var(--ink);}
+  .navlinks button:focus-visible{
+    outline:2px solid var(--stamp-blue);
+    outline-offset:2px;
+    border-radius:1px;
+  }
+  .navlinks button:focus:not(:focus-visible){outline:none;}
 
   /* STAMP */
   .stamp{


### PR DESCRIPTION
## Summary

Improves keyboard and assistive-technology accessibility for the top navigation, per #297.

### Changes

1. **Semantic landmarks** (`TopNav.tsx`)
   - Added `aria-label="Main navigation"` to the `<nav>` element so the landmark has a useful name for screen readers.
   - Added `aria-current="page"` on the active view button, so assistive tech announces the current view.

2. **Visible focus styles** (`index.css`)
   - Added global `:focus-visible` outline (2px solid `--stamp-blue`) for all interactive elements.
   - Added `:focus:not(:focus-visible)` rule so the outline only shows for keyboard users, not mouse clicks.
   - Scoped nav-specific focus styles for the top nav buttons using the design-token color.

3. **Skip-to-content link** (`App.tsx`, `index.css`)
   - Added a visually hidden (until focused) `Skip to content` link as the first focusable element, letting keyboard users jump past the nav directly to `#main-content`.
   - Rendered the active view inside `<div id="main-content">` as the link target.

### Verification

- [x] Keyboard-only test: Tab to nav buttons, Enter/Space activates, focus ring visible.
- [x] Screen reader: nav announced as "Main navigation", active button announced with `aria-current`.
- [x] `npm run lint` passes (0 errors).
- [x] `tsc --noEmit` passes.
- [x] `vite build` passes.

## Acceptance criteria

- [x] All navigation actions are keyboard reachable.
- [x] Focus is always visible.
- [x] Screen readers receive useful names.

## Testing

- [x] Tested with keyboard only.
- [x] Reviewed with automated accessibility scan (axe-style focus ordering).
- [x] Frontend lint passes.

## Notes

- Branch name follows `CONTRIBUTING.md` (`feat/…`).
- Conventional commit used: `feat(frontend): …`.
- No generated artifacts, `.env` files, secrets, or unrelated lockfile churn.

Closes #297