### PR TITLE
feat(frontend): add filtering and sorting controls to the ledger (Closes #299)

### DIFF
--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -263,3 +263,35 @@
   .pill.pending{color:var(--ink-faint);}
 
   .panel-title{font-family:var(--mono-display); font-weight:700; font-size:15px; margin:0 0 14px;}
+
+  /* FILTER BAR */
+  .filter-bar{
+    display:flex; align-items:center; gap:28px; flex-wrap:wrap;
+    margin-bottom:20px; padding:12px 0; border-bottom:1px solid var(--rule);
+  }
+  .filter-group{display:flex; align-items:center; gap:6px; flex-wrap:wrap;}
+  .filter-label{
+    font-family:var(--mono-data); font-size:10.5px; text-transform:uppercase;
+    letter-spacing:0.08em; color:var(--ink-faint); margin-right:4px;
+  }
+  .filter-chip{
+    font-family:var(--mono-data); font-size:12px;
+    background:none; border:1px solid var(--rule-strong); border-radius:2px;
+    padding:4px 10px; cursor:pointer; color:var(--ink-soft);
+    transition:all 0.12s;
+  }
+  .filter-chip:hover{border-color:var(--ink); color:var(--ink);}
+  .filter-chip.active{
+    background:var(--ink); color:var(--paper); border-color:var(--ink);
+  }
+
+  .table-head{
+    display:flex; align-items:baseline; justify-content:space-between; gap:12px;
+  }
+  .result-count{
+    font-family:var(--mono-data); font-size:12px; color:var(--ink-faint);
+  }
+  .empty-state{
+    font-family:var(--mono-data); font-size:14px; color:var(--ink-soft);
+    padding:40px 0; text-align:center;
+  }

--- a/apps/frontend/src/pages/Dashboard.tsx
+++ b/apps/frontend/src/pages/Dashboard.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { Stamp } from "../components/Stamp";
 
 const NAV_GROUPS = [
@@ -39,7 +39,49 @@ const ENTRIES = [
   { account: "GF5H...R3UB", model: "credit-score", score: "598", status: "flagged", time: "3:47 ago" },
 ] as const;
 
+type EntryStatus = (typeof ENTRIES)[number]["status"];
+type SortKey = "time" | "account" | "model" | "score";
+
+const STATUS_OPTIONS: EntryStatus[] = ["approved", "flagged", "pending"];
+
 export function Dashboard() {
+  const [statusFilter, setStatusFilter] = useState<EntryStatus | "all">("all");
+  const [sortBy, setSortBy] = useState<SortKey>("time");
+  const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
+
+  const filtered = ENTRIES.filter(
+    (e) => statusFilter === "all" || e.status === statusFilter
+  );
+
+  const sorted = [...filtered].sort((a, b) => {
+    const dir = sortDir === "asc" ? 1 : -1;
+    const cmp = a[sortBy].localeCompare(b[sortBy]);
+    // 对于 score 列，数值比较
+    if (sortBy === "score") {
+      const nA = parseInt(a.score, 10);
+      const nB = parseInt(b.score, 10);
+      if (isNaN(nA) && isNaN(nB)) return dir * cmp;
+      if (isNaN(nA)) return 1;
+      if (isNaN(nB)) return -1;
+      return dir * (nA - nB);
+    }
+    return dir * cmp;
+  });
+
+  const toggleSort = (key: SortKey) => {
+    if (sortBy === key) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortBy(key);
+      setSortDir("asc");
+    }
+  };
+
+  const sortArrow = (key: SortKey) => {
+    if (sortBy !== key) return "";
+    return sortDir === "asc" ? " ▲" : " ▼";
+  };
+
   return (
     <div className="app-shell">
       <aside className="sidebar">
@@ -78,31 +120,91 @@ export function Dashboard() {
           ))}
         </div>
 
-        <p className="panel-title">Recent ledger entries</p>
-        <table className="ledger-table">
-          <thead>
-            <tr>
-              <th>Account</th>
-              <th>Model</th>
-              <th>Score</th>
-              <th>Status</th>
-              <th>Time</th>
-            </tr>
-          </thead>
-          <tbody>
-            {ENTRIES.map((e) => (
-              <tr key={e.account + e.time}>
-                <td>{e.account}</td>
-                <td>{e.model}</td>
-                <td>{e.score}</td>
-                <td>
-                  <span className={`pill ${e.status}`}>{e.status}</span>
-                </td>
-                <td>{e.time}</td>
-              </tr>
+        <div className="filter-bar">
+          <div className="filter-group">
+            <span className="filter-label">Status</span>
+            <button
+              className={`filter-chip ${statusFilter === "all" ? "active" : ""}`}
+              onClick={() => setStatusFilter("all")}
+            >
+              All
+            </button>
+            {STATUS_OPTIONS.map((s) => (
+              <button
+                key={s}
+                className={`filter-chip ${statusFilter === s ? "active" : ""}`}
+                onClick={() => setStatusFilter(s)}
+              >
+                {s}
+              </button>
             ))}
-          </tbody>
-        </table>
+          </div>
+          <div className="filter-group">
+            <span className="filter-label">Sort</span>
+            <button
+              className={`filter-chip ${sortBy === "time" ? "active" : ""}`}
+              onClick={() => toggleSort("time")}
+            >
+              Time{sortArrow("time")}
+            </button>
+            <button
+              className={`filter-chip ${sortBy === "account" ? "active" : ""}`}
+              onClick={() => toggleSort("account")}
+            >
+              Account{sortArrow("account")}
+            </button>
+            <button
+              className={`filter-chip ${sortBy === "model" ? "active" : ""}`}
+              onClick={() => toggleSort("model")}
+            >
+              Model{sortArrow("model")}
+            </button>
+            <button
+              className={`filter-chip ${sortBy === "score" ? "active" : ""}`}
+              onClick={() => toggleSort("score")}
+            >
+              Score{sortArrow("score")}
+            </button>
+          </div>
+        </div>
+
+        <div className="table-head">
+          <p className="panel-title">Recent ledger entries</p>
+          <span className="result-count">
+            {sorted.length} of {ENTRIES.length}
+          </span>
+        </div>
+
+        {sorted.length > 0 ? (
+          <table className="ledger-table">
+            <thead>
+              <tr>
+                <th>Account</th>
+                <th>Model</th>
+                <th>Score</th>
+                <th>Status</th>
+                <th>Time</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map((e) => (
+                <tr key={e.account + e.time}>
+                  <td>{e.account}</td>
+                  <td>{e.model}</td>
+                  <td>{e.score}</td>
+                  <td>
+                    <span className={`pill ${e.status}`}>{e.status}</span>
+                  </td>
+                  <td>{e.time}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          <div className="empty-state">
+            No entries match the current filter.
+          </div>
+        )}
       </main>
     </div>
   );


### PR DESCRIPTION
## Summary

Adds client-side filtering and sorting controls for the ledger entries table, per #299.

### Changes

1. **`Dashboard.tsx`** — added state-driven filter and sort:
   - **Status filter chips**: All / approved / flagged / pending — click to narrow the displayed entries.
   - **Sort controls**: Time / Account / Model / Score — click to sort ascending, click again to toggle direction. Active sort column shows ▲/▼ arrow.
   - **Result count**: shows `N of M` so the user always knows how many entries match the filter.
   - **Empty state**: when the active filter eliminates all entries, a centered message replaces the table.
   - **Score column**: numeric-aware sorting (`parseInt`) so `742 > 681 > 598`, with `—` falling to the end.

2. **`index.css`** — new filter bar styles:
   - `.filter-bar`: flex row with two groups (Status + Sort), wraps on narrow screens.
   - `.filter-chip`: small bordered button, `.active` state gets filled background.
   - `.table-head`: flex row for the panel title + result count.
   - `.empty-state`: centered message for empty filtered results.

### Acceptance criteria

- [x] Filters compose predictably — status chips are additive to sort column.
- [x] Sorting is stable — equal values keep their original order (no `|| 0` fallback that would break localeCompare).
- [x] Empty filtered results are explained — `No entries match the current filter.`

### Testing

- [x] Test each filter individually and combined.
- [x] Test sorting with equal values.
- [x] `npm run lint` passes, `tsc --noEmit` passes, `vite build` passes.

Closes #299