### PR TITLE
Add secret scanning guidance for contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,3 +76,44 @@ cd contracts
 cargo build
 cargo test
 ```
+
+## Secret scanning
+
+**Never commit secrets, API keys, or sensitive credentials to the repository.**
+
+### What to avoid
+
+- API keys (Stripe, OpenAI, AWS, etc.)
+- Private keys or certificates
+- Database credentials
+- OAuth tokens
+- Environment files containing secrets (`.env`, `.env.local`)
+- Personal access tokens
+
+### Pre-commit checks
+
+Before committing, run secret scanning locally:
+
+```bash
+# Using truffleHog (recommended)
+npx trufflehog filesystem .
+
+# Or using gitleaks
+gitleaks detect --source .
+```
+
+### If you accidentally commit a secret
+
+1. **Do not** just remove it from the latest commit — the secret remains in git history
+2. Rotate/revolve the compromised credential immediately
+3. Remove the secret from all commits using `git filter-repo` or BFG Repo-Cleaner
+4. Force push with caution (notify team first)
+5. Consider the repository compromised if it was a high-value secret
+
+### Best practices
+
+- Use environment variables for secrets (document required variables in `.env.example`)
+- Add `.env` and `.env.local` to `.gitignore`
+- Use secret management services (e.g., AWS Secrets Manager, HashiCorp Vault) for production
+- Enable GitHub secret scanning in repository settings (enabled by default on public repos)
+- Review the [GitHub Secret Scanning documentation](https://docs.github.com/en/code-security/secret-scanning)


### PR DESCRIPTION
Description
This PR updates the contributor documentation to include guidance on preventing accidental exposure of sensitive information (such as API keys, tokens, or passwords) in the repository.

Changes
Added a new section in CONTRIBUTING.md titled Secret Scanning Guidance.

Outlined best practices:

Never hardcode secrets in code.

Use environment variables and configuration files.

Ensure .env and other sensitive files are listed in .gitignore.

Run local secret scanning tools (e.g., git-secrets, trufflehog) before committing.

Added instructions for remediation if a secret is accidentally committed:

Rotate the secret immediately.

Remove the secret from commit history using tools like git filter-repo or BFG Repo-Cleaner.

Notify maintainers if the secret is project-related.

Linked to GitHub’s official secret scanning documentation [(docs.github.com in Bing)](https://www.bing.com/search?q=%22https%3A%2F%2Fdocs.github.com%2Fen%2Fcode-security%2Fsecret-scanning%2Fabout-secret-scanning%22&utm_source=copilot.com).

Motivation
Protect contributors and the project from security risks.

Align with industry best practices for secure development.

Improve onboarding by making expectations clear and actionable.

Checklist
[x] Documentation updated

[x] Security best practices included

[x] Reference to GitHub secret scanning added
Close #332 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for detecting and preventing accidentally committed secrets.
  * Documented local secret-scanning checks, remediation steps, prohibited secret types, and best practices for secret management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->