### PR TITLE
feat(ci): add pull request checklist validation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,45 @@
+<!--
+Keep the `## ` headings below — the "PR Checklist" workflow
+(.github/workflows/pr-checklist.yml) validates that Summary, Testing done and
+Checklist are present and filled in. Screenshots is additionally required when
+the diff touches UI files.
+
+Delete the hint comments as you go; they don't count as content.
+-->
+
+## Summary
+
+<!--
+What does this change, and why? One or two paragraphs is plenty.
+Link the issue this closes, e.g. "Closes #123".
+-->
+
+## Testing done
+
+<!--
+The commands you actually ran and what you verified. For example:
+
+- `pnpm test:all`
+- `cd contracts && cargo test --workspace`
+- Manually checked <flow> in the browser
+
+Write "N/A" plus a reason if this genuinely cannot be tested.
+-->
+
+## Screenshots
+
+<!--
+Required for any UI change (`apps/frontend/**`, `*.tsx`, `*.css`, ...).
+Before/after images or a short recording. Otherwise: "N/A — no UI surface".
+-->
+
+## Checklist
+
+<!-- See CONTRIBUTING.md. Tick what applies; at least one box must be ticked. -->
+
+- [ ] Branch follows the naming convention (`feat/`, `fix/`, `chore/`, `docs/`, `refactor/`)
+- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope): summary`)
+- [ ] The PR is scoped to one domain / one issue, with no unrelated churn
+- [ ] All CI checks are green (see the CI requirements in `CONTRIBUTING.md`)
+- [ ] Docs updated where behavior changed
+- [ ] Screenshots attached for UI changes

--- a/.github/scripts/check-pr-checklist.mjs
+++ b/.github/scripts/check-pr-checklist.mjs
@@ -1,0 +1,356 @@
+#!/usr/bin/env node
+/**
+ * Contributor pull request checklist validation.
+ *
+ * The interesting part of this file is pure: `checkPullRequest()` takes a PR
+ * body (plus, optionally, the list of changed files, the author and the
+ * labels) and returns which required sections are missing. That keeps it
+ * unit-testable without GitHub in the loop — see `check-pr-checklist.test.mjs`.
+ *
+ * The CLI wrapper at the bottom only reads the webhook payload GitHub already
+ * wrote to disk (`GITHUB_EVENT_PATH`). It needs no token and no secrets.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+/** Sections every pull request must fill in. */
+export const REQUIRED_SECTIONS = [
+  {
+    id: 'summary',
+    title: 'Summary',
+    aliases: ['summary', 'overview', 'what changed', 'description'],
+    hint: 'Describe what this PR changes and why.',
+  },
+  {
+    id: 'testing',
+    title: 'Testing done',
+    aliases: [
+      'testing done',
+      'testing',
+      'tests',
+      'how has this been tested',
+      'test plan',
+    ],
+    hint: 'List the commands you ran (e.g. `pnpm test:all`) and what you verified.',
+  },
+  {
+    id: 'checklist',
+    title: 'Checklist',
+    aliases: ['checklist'],
+    requiresTickedBox: true,
+    hint: 'Tick the boxes you satisfied (branch naming, conventional commits, green CI).',
+  },
+];
+
+/** Sections only required when the diff touches user-facing code. */
+export const CONDITIONAL_SECTIONS = [
+  {
+    id: 'screenshots',
+    title: 'Screenshots',
+    aliases: [
+      'screenshots',
+      'screenshots for ui changes',
+      'screenshots recordings',
+      'screenshots or recordings',
+    ],
+    hint: 'This PR touches UI files — attach a screenshot/recording, or write "N/A" with a reason.',
+    requiredWhen: (changedFiles) => changedFiles.some(isUiFile),
+  },
+];
+
+/** Maintainer-applied label that skips the whole check. */
+export const BYPASS_LABEL = 'skip-checklist';
+
+/** Automation accounts whose PRs never carry a hand-written template. */
+export const BOT_AUTHORS = [
+  'dependabot[bot]',
+  'github-actions[bot]',
+  'renovate[bot]',
+  'pre-commit-ci[bot]',
+];
+
+const UI_FILE_RE = /(^apps\/frontend\/)|(\.(tsx|jsx|css|scss|svg)$)/i;
+
+/** True when a changed path is user-facing enough to warrant a screenshot. */
+export function isUiFile(filePath) {
+  return UI_FILE_RE.test(String(filePath).trim());
+}
+
+/**
+ * Collapse a markdown heading down to comparable text: drop emoji, inline
+ * code, bold/italic markers and punctuation, then lowercase.
+ */
+export function normalizeHeading(text) {
+  return String(text)
+    .replace(/`([^`]*)`/g, '$1')
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/[^\p{L}\p{N}\s]+/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+/** Strip HTML comments — that is how the template carries its hints. */
+function stripComments(body) {
+  return String(body).replace(/<!--[\s\S]*?-->/g, '');
+}
+
+/**
+ * Split a PR body into `{ heading, normalized, level, content }` sections.
+ * Fenced code blocks are skipped so a `# comment` inside a snippet is not
+ * mistaken for a heading.
+ */
+export function parseSections(body) {
+  const lines = stripComments(body ?? '')
+    .replace(/\r\n?/g, '\n')
+    .split('\n');
+
+  const sections = [];
+  let current = null;
+  let inFence = false;
+
+  for (const line of lines) {
+    if (/^\s{0,3}(```|~~~)/.test(line)) inFence = !inFence;
+
+    const heading = inFence ? null : line.match(/^\s{0,3}(#{1,6})\s+(.+?)\s*#*\s*$/);
+    if (heading) {
+      current = {
+        heading: heading[2].trim(),
+        normalized: normalizeHeading(heading[2]),
+        level: heading[1].length,
+        lines: [],
+      };
+      sections.push(current);
+      continue;
+    }
+
+    if (current) current.lines.push(line);
+  }
+
+  return sections.map(({ lines: sectionLines, ...rest }) => ({
+    ...rest,
+    content: sectionLines.join('\n').trim(),
+  }));
+}
+
+/** A section counts as unfilled if only blanks/empty checkboxes remain. */
+function isBlank(content) {
+  return (
+    String(content)
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+      .filter((line) => !/^[-*]?\s*\[[ xX]\]\s*$/.test(line))
+      .filter((line) => !/^[-*_\s]{3,}$/.test(line))
+      .join('')
+      .trim().length === 0
+  );
+}
+
+/** At least one `- [x]` in the section. */
+function hasTickedBox(content) {
+  return /^\s*[-*]?\s*\[[xX]\]\s+\S/m.test(String(content));
+}
+
+function findSection(sections, spec) {
+  const aliases = spec.aliases.map(normalizeHeading);
+  return sections.find(
+    (section) =>
+      aliases.includes(section.normalized) ||
+      aliases.some(
+        (alias) =>
+          section.normalized.startsWith(`${alias} `) ||
+          section.normalized.endsWith(` ${alias}`),
+      ),
+  );
+}
+
+/**
+ * Reason this PR is exempt from the check, or `null` if it must be validated.
+ * Bypass paths: a maintainer-applied `skip-checklist` label, or a bot author.
+ */
+export function getBypassReason({ author = '', labels = [] } = {}) {
+  const normalizedLabels = labels
+    .map((label) => (typeof label === 'string' ? label : label?.name ?? ''))
+    .map((name) => String(name).trim().toLowerCase());
+
+  if (normalizedLabels.includes(BYPASS_LABEL)) {
+    return `the "${BYPASS_LABEL}" label is applied`;
+  }
+
+  const login = String(author).trim().toLowerCase();
+  if (login && (BOT_AUTHORS.includes(login) || login.endsWith('[bot]'))) {
+    return `the author "${author}" is an automation account`;
+  }
+
+  return null;
+}
+
+/**
+ * Validate a pull request body against the template.
+ *
+ * @param {object} input
+ * @param {string} input.body           PR description.
+ * @param {string[]} [input.changedFiles] Paths changed by the PR.
+ * @param {string} [input.author]       PR author login.
+ * @param {Array}  [input.labels]       Label names (or label objects).
+ * @returns {{ok: boolean, skipped: boolean, skipReason: (string|null),
+ *            problems: Array<{id: string, title: string, reason: string, hint: string}>,
+ *            satisfied: string[]}}
+ */
+export function checkPullRequest({
+  body = '',
+  changedFiles = [],
+  author = '',
+  labels = [],
+} = {}) {
+  const skipReason = getBypassReason({ author, labels });
+  if (skipReason) {
+    return { ok: true, skipped: true, skipReason, problems: [], satisfied: [] };
+  }
+
+  const sections = parseSections(body);
+  const files = (changedFiles ?? []).map(String).filter(Boolean);
+
+  const specs = [
+    ...REQUIRED_SECTIONS,
+    ...CONDITIONAL_SECTIONS.filter((spec) => spec.requiredWhen(files)),
+  ];
+
+  const problems = [];
+  const satisfied = [];
+
+  for (const spec of specs) {
+    const section = findSection(sections, spec);
+
+    if (!section) {
+      problems.push({
+        id: spec.id,
+        title: spec.title,
+        reason: `missing the "## ${spec.title}" section`,
+        hint: spec.hint,
+      });
+      continue;
+    }
+
+    if (isBlank(section.content)) {
+      problems.push({
+        id: spec.id,
+        title: spec.title,
+        reason: `the "## ${spec.title}" section is empty`,
+        hint: spec.hint,
+      });
+      continue;
+    }
+
+    if (spec.requiresTickedBox && !hasTickedBox(section.content)) {
+      problems.push({
+        id: spec.id,
+        title: spec.title,
+        reason: `the "## ${spec.title}" section has no ticked "- [x]" item`,
+        hint: spec.hint,
+      });
+      continue;
+    }
+
+    satisfied.push(spec.title);
+  }
+
+  return {
+    ok: problems.length === 0,
+    skipped: false,
+    skipReason: null,
+    problems,
+    satisfied,
+  };
+}
+
+/** Human-readable markdown report for the job summary / logs. */
+export function formatReport(result) {
+  if (result.skipped) {
+    return `## PR checklist\n\nSkipped — ${result.skipReason}.`;
+  }
+
+  if (result.ok) {
+    const list = result.satisfied.map((title) => `- \`${title}\``).join('\n');
+    return `## PR checklist\n\nAll required sections are present:\n\n${list}`;
+  }
+
+  const list = result.problems
+    .map((problem) => `- **${problem.title}** — ${problem.reason}.\n  ${problem.hint}`)
+    .join('\n');
+
+  return [
+    '## PR checklist',
+    '',
+    `This pull request is ${result.problems.length === 1 ? 'missing 1 required item' : `missing ${result.problems.length} required items`}:`,
+    '',
+    list,
+    '',
+    'Copy the structure from `.github/PULL_REQUEST_TEMPLATE.md` into the PR',
+    'description and fill it in — the check re-runs automatically on edit.',
+    '',
+    `Maintainers can bypass this with the \`${BYPASS_LABEL}\` label.`,
+  ].join('\n');
+}
+
+/* ------------------------------------------------------------------------ *
+ * CLI: reads only the webhook payload GitHub wrote to disk. No token, no
+ * secrets, no network.
+ * ------------------------------------------------------------------------ */
+
+function readChangedFiles() {
+  const raw = process.env.CHANGED_FILES ?? '';
+  return raw
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function readEvent() {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath || !fs.existsSync(eventPath)) return null;
+  return JSON.parse(fs.readFileSync(eventPath, 'utf8'));
+}
+
+export function main() {
+  const event = readEvent();
+  const pr = event?.pull_request;
+
+  if (!pr) {
+    console.log('No pull_request payload found — nothing to validate.');
+    return 0;
+  }
+
+  const result = checkPullRequest({
+    body: pr.body ?? '',
+    changedFiles: readChangedFiles(),
+    author: pr.user?.login ?? '',
+    labels: pr.labels ?? [],
+  });
+
+  const report = formatReport(result);
+  console.log(report);
+
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${report}\n`);
+  }
+
+  if (result.skipped || result.ok) return 0;
+
+  for (const problem of result.problems) {
+    console.log(`::error title=PR checklist::${problem.reason}. ${problem.hint}`);
+  }
+
+  return 1;
+}
+
+const invokedDirectly =
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+
+if (invokedDirectly) {
+  process.exitCode = main();
+}

--- a/.github/scripts/check-pr-checklist.test.mjs
+++ b/.github/scripts/check-pr-checklist.test.mjs
@@ -1,0 +1,254 @@
+/**
+ * Unit tests for the PR checklist validator.
+ *
+ * Run locally with:  node --test .github/scripts/
+ * CI runs the same command in .github/workflows/pr-checklist.yml.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  BYPASS_LABEL,
+  checkPullRequest,
+  formatReport,
+  getBypassReason,
+  isUiFile,
+  normalizeHeading,
+  parseSections,
+} from './check-pr-checklist.mjs';
+
+const VALID_BODY = `## Summary
+
+Adds a checklist validation workflow so incomplete PRs are caught early.
+
+Closes #326
+
+## Testing done
+
+- \`node --test .github/scripts/\` — 20 unit tests pass.
+- Validated the workflow YAML with \`yaml.safe_load\`.
+
+## Screenshots
+
+N/A — CI-only change, no UI surface.
+
+## Checklist
+
+- [x] Branch follows \`feat/<short-description>\`
+- [x] Commits follow Conventional Commits
+- [ ] Screenshots attached for UI changes
+`;
+
+const missingIds = (result) => result.problems.map((problem) => problem.id);
+
+test('a fully valid body passes', () => {
+  const result = checkPullRequest({ body: VALID_BODY });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.skipped, false);
+  assert.deepEqual(result.problems, []);
+  assert.deepEqual(result.satisfied, ['Summary', 'Testing done', 'Checklist']);
+});
+
+test('a body missing the Summary section fails and says so', () => {
+  const body = VALID_BODY.replace(
+    /## Summary[\s\S]*?(?=## Testing done)/,
+    '',
+  );
+  const result = checkPullRequest({ body });
+
+  assert.equal(result.ok, false);
+  assert.deepEqual(missingIds(result), ['summary']);
+  assert.match(result.problems[0].reason, /missing the "## Summary" section/);
+  assert.match(formatReport(result), /Summary/);
+});
+
+test('a body missing Testing done fails', () => {
+  const body = VALID_BODY.replace(
+    /## Testing done[\s\S]*?(?=## Screenshots)/,
+    '',
+  );
+  const result = checkPullRequest({ body });
+
+  assert.equal(result.ok, false);
+  assert.deepEqual(missingIds(result), ['testing']);
+  assert.match(result.problems[0].reason, /"## Testing done"/);
+});
+
+test('an empty body reports every required section', () => {
+  const result = checkPullRequest({ body: '' });
+
+  assert.equal(result.ok, false);
+  assert.deepEqual(missingIds(result), ['summary', 'testing', 'checklist']);
+});
+
+test('a null/undefined body is treated as empty rather than throwing', () => {
+  assert.equal(checkPullRequest({ body: null }).ok, false);
+  assert.equal(checkPullRequest().ok, false);
+});
+
+test('a body that is only the unfilled template fails', () => {
+  const body = `## Summary
+
+<!-- What does this change and why? -->
+
+## Testing done
+
+<!-- Commands you ran. -->
+
+## Checklist
+
+- [ ] Branch follows the naming convention
+- [ ] Commits follow Conventional Commits
+`;
+  const result = checkPullRequest({ body });
+
+  assert.equal(result.ok, false);
+  assert.deepEqual(missingIds(result), ['summary', 'testing', 'checklist']);
+  assert.match(result.problems[0].reason, /is empty/);
+  assert.match(result.problems[2].reason, /no ticked/);
+});
+
+test('a Checklist with no ticked box fails', () => {
+  const body = VALID_BODY.replace('- [x] Branch', '- [ ] Branch').replace(
+    '- [x] Commits',
+    '- [ ] Commits',
+  );
+  const result = checkPullRequest({ body });
+
+  assert.equal(result.ok, false);
+  assert.deepEqual(missingIds(result), ['checklist']);
+});
+
+test('heading aliases and emoji decoration are accepted', () => {
+  const body = `### 📌 Summary
+Rewrites the retry backoff.
+
+### 🧪 Test plan
+\`cargo test --workspace\`
+
+### ✅ Checklist
+- [x] CI is green
+`;
+
+  assert.equal(checkPullRequest({ body }).ok, true);
+});
+
+test('headings inside fenced code blocks are not counted as sections', () => {
+  const body = `\`\`\`md
+## Summary
+## Testing done
+## Checklist
+- [x] nope
+\`\`\`
+`;
+  const result = checkPullRequest({ body });
+
+  assert.equal(result.ok, false);
+  assert.deepEqual(missingIds(result), ['summary', 'testing', 'checklist']);
+});
+
+test('Screenshots is required only when the diff touches UI files', () => {
+  const body = VALID_BODY.replace(
+    /## Screenshots[\s\S]*?(?=## Checklist)/,
+    '',
+  );
+
+  assert.equal(
+    checkPullRequest({ body, changedFiles: ['.github/workflows/ci.yml'] }).ok,
+    true,
+    'non-UI diff should not require screenshots',
+  );
+
+  const uiResult = checkPullRequest({
+    body,
+    changedFiles: ['apps/frontend/src/App.tsx'],
+  });
+  assert.equal(uiResult.ok, false);
+  assert.deepEqual(missingIds(uiResult), ['screenshots']);
+});
+
+test('isUiFile recognises frontend and style paths only', () => {
+  assert.equal(isUiFile('apps/frontend/src/main.ts'), true);
+  assert.equal(isUiFile('packages/ui/Button.tsx'), true);
+  assert.equal(isUiFile('docs/theme.css'), true);
+  assert.equal(isUiFile('apps/backend/src/server.ts'), false);
+  assert.equal(isUiFile('.github/workflows/pr-checklist.yml'), false);
+});
+
+test('the bypass label skips validation even for an empty body', () => {
+  const result = checkPullRequest({ body: '', labels: [BYPASS_LABEL] });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.skipped, true);
+  assert.match(result.skipReason, /skip-checklist/);
+  assert.match(formatReport(result), /^## PR checklist\n\nSkipped —/);
+});
+
+test('the bypass label is matched case-insensitively and as a label object', () => {
+  assert.equal(
+    checkPullRequest({ body: '', labels: [{ name: 'Skip-Checklist' }] }).skipped,
+    true,
+  );
+});
+
+test('bot authors are exempt', () => {
+  for (const author of [
+    'dependabot[bot]',
+    'github-actions[bot]',
+    'renovate[bot]',
+    'some-other-app[bot]',
+  ]) {
+    const result = checkPullRequest({ body: '', author });
+    assert.equal(result.skipped, true, `${author} should be exempt`);
+    assert.match(result.skipReason, /automation account/);
+  }
+});
+
+test('a human author with an unrelated label is not exempt', () => {
+  assert.equal(getBypassReason({ author: 'octocat', labels: ['bug'] }), null);
+  assert.equal(getBypassReason(), null);
+  assert.equal(checkPullRequest({ body: '', author: 'octocat' }).skipped, false);
+});
+
+test('the failure report names every missing section and the bypass label', () => {
+  const report = formatReport(checkPullRequest({ body: '' }));
+
+  assert.match(report, /missing 3 required items/);
+  assert.match(report, /\*\*Summary\*\*/);
+  assert.match(report, /\*\*Testing done\*\*/);
+  assert.match(report, /\*\*Checklist\*\*/);
+  assert.match(report, /PULL_REQUEST_TEMPLATE\.md/);
+  assert.match(report, new RegExp(BYPASS_LABEL));
+});
+
+test('the success report lists the satisfied sections', () => {
+  const report = formatReport(checkPullRequest({ body: VALID_BODY }));
+
+  assert.match(report, /All required sections are present/);
+  assert.match(report, /`Testing done`/);
+});
+
+test('normalizeHeading strips emoji, formatting and punctuation', () => {
+  assert.equal(normalizeHeading('## 🧪 **Testing done**:'), 'testing done');
+  assert.equal(normalizeHeading('`Checklist`'), 'checklist');
+  assert.equal(normalizeHeading('Screenshots / recordings'), 'screenshots recordings');
+});
+
+test('parseSections captures heading text and content, ignoring comments', () => {
+  const sections = parseSections(
+    '## Summary\n<!-- hint -->\nreal content\n\n## Testing done\n`npm test`\n',
+  );
+
+  assert.equal(sections.length, 2);
+  assert.equal(sections[0].heading, 'Summary');
+  assert.equal(sections[0].level, 2);
+  assert.equal(sections[0].content, 'real content');
+  assert.equal(sections[1].content, '`npm test`');
+});
+
+test('CRLF bodies are handled', () => {
+  const result = checkPullRequest({ body: VALID_BODY.replace(/\n/g, '\r\n') });
+  assert.equal(result.ok, true);
+});

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,16 +1,59 @@
 # CI/CD
 
-Three independent pipelines, one per area of the monorepo. Each is
+Three independent build pipelines, one per area of the monorepo. Each is
 **path-filtered**, so touching the frontend never spins up a Rust toolchain.
+A fourth workflow, `pr-checklist.yml`, is intentionally *not* path-filtered and
+runs on every pull request.
 
 | Workflow | Triggers on changes to | What it does |
 | --- | --- | --- |
 | `frontend.yml` | `apps/frontend/**` | install (npm) → lint → typecheck → test → `vite build` → upload `dist` |
 | `backend.yml` | `apps/backend/**`, `packages/**`, `pnpm-workspace.yaml` | install (pnpm) → `prisma generate` → lint → typecheck → test → build; plus a separate shared-packages build job |
 | `contracts.yml` | `contracts/**` | Rust toolchain + wasm target → `cargo fmt --check` → `clippy` → `test` → release wasm build → upload `.wasm` |
+| `pr-checklist.yml` | *every pull request* | unit-tests the validator → validates the PR description against `.github/PULL_REQUEST_TEMPLATE.md` |
 
-All three also run on `pull_request` and can be started manually via
+All of them also run on `pull_request` and can be started manually via
 **workflow_dispatch**.
+
+## PR checklist validation
+
+`pr-checklist.yml` fails a pull request whose description is missing the
+sections `.github/PULL_REQUEST_TEMPLATE.md` asks for, with an annotation and a
+job summary naming exactly what is absent.
+
+- **Required:** `## Summary`, `## Testing done`, and `## Checklist` (with at
+  least one `- [x]` ticked). Heading aliases (`Test plan`, `Overview`, …),
+  emoji and `###` levels are all accepted; headings inside fenced code blocks
+  are not.
+- **Conditionally required:** `## Screenshots`, when the diff touches UI files
+  (`apps/frontend/**`, `*.tsx`, `*.jsx`, `*.css`, `*.scss`, `*.svg`).
+- **Unfilled counts as missing.** The template's hints are HTML comments, which
+  are stripped before a section is checked for content.
+- **Bypass:** apply the maintainer-only `skip-checklist` label, or open the PR
+  as a bot (`dependabot[bot]`, `github-actions[bot]`, `renovate[bot]`, or any
+  `*[bot]` login). `labeled`/`unlabeled` are trigger types, so the label takes
+  effect right away.
+
+The rules live in `.github/scripts/check-pr-checklist.mjs` as a pure function
+and are covered by `.github/scripts/check-pr-checklist.test.mjs`. The workflow
+runs those tests as one of its own steps. Locally:
+
+```bash
+node --test '.github/scripts/*.test.mjs'
+```
+
+### Why `pull_request` and not `pull_request_target`
+
+The workflow executes contributor-authored code from the PR head, so it uses
+the plain `pull_request` trigger: on fork PRs GitHub hands the job a
+**read-only `GITHUB_TOKEN` and no repository secrets**, leaving nothing
+privileged to exfiltrate. `pull_request_target` would grant a write token and
+secrets while running against a ref the contributor controls — and validating a
+description needs neither. That read-only token is also why the check *fails
+loudly* instead of posting a bot comment (commenting needs
+`pull-requests: write`, which fork PRs cannot have here). The PR body itself is
+untrusted input and is never interpolated into a shell command via `${{ … }}`;
+the validator reads it from the webhook payload on disk (`GITHUB_EVENT_PATH`).
 
 ## Designed to be green today, meaningful tomorrow
 

--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -1,0 +1,79 @@
+name: PR Checklist
+
+# Unlike frontend.yml / backend.yml / contracts.yml, this workflow is
+# deliberately NOT path-filtered: every pull request needs a filled-in
+# description, whatever it touches.
+#
+# `labeled`/`unlabeled` are included so applying the `skip-checklist` bypass
+# label re-runs the check immediately instead of waiting for the next push.
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize, labeled, unlabeled]
+  workflow_dispatch:
+
+# ---------------------------------------------------------------------------
+# Fork safety
+# ---------------------------------------------------------------------------
+# This uses the plain `pull_request` trigger, never `pull_request_target`.
+#
+# * `pull_request` runs in the context of the *fork's* merge ref. For PRs from
+#   forks GitHub issues a `GITHUB_TOKEN` that is read-only, and repository
+#   secrets are NOT injected into the job. So even though the steps below
+#   execute contributor-authored code from the PR head, that code has nothing
+#   privileged to steal.
+# * `pull_request_target` would do the opposite: run with a read/write token
+#   and full access to secrets, against a ref the contributor controls. That is
+#   the classic exfiltration hole, and it buys us nothing here — validating a PR
+#   description needs no write access.
+# * Because the token is read-only on forks, this check *fails the job* with
+#   annotations and a job summary rather than posting a review comment. A bot
+#   comment would need `pull-requests: write`, which fork PRs cannot get under
+#   `pull_request` — the failure + summary is the actionable signal instead.
+# * The PR body is untrusted input. It is never interpolated into a shell
+#   command via `${{ ... }}`; the validator reads it from the webhook payload
+#   on disk (`GITHUB_EVENT_PATH`), which sidesteps script injection entirely.
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-checklist-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  checklist:
+    name: Validate PR description
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Two commits: the PR merge commit and its parents, enough to diff
+          # the PR against its base without a full clone.
+          fetch-depth: 2
+
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      # The validator is pure and unit-tested; the tests run here so a
+      # regression in the rules is caught on every PR, not just when someone
+      # remembers to run them locally.
+      - name: Unit test the validator
+        run: node --test '.github/scripts/*.test.mjs'
+
+      # Only used to decide whether the "Screenshots" section is required.
+      # Computed from git (no API call, no token). If the shallow history
+      # cannot produce a diff we fall back to an empty list, which simply
+      # means screenshots are not demanded.
+      - name: Collect changed files
+        run: |
+          {
+            echo 'CHANGED_FILES<<__EOF__'
+            git diff --name-only HEAD^1 HEAD 2>/dev/null || true
+            echo '__EOF__'
+          } >> "$GITHUB_ENV"
+
+      - name: Validate PR description
+        run: node .github/scripts/check-pr-checklist.mjs


### PR DESCRIPTION
## Summary

Adds an automated contributor checklist validation so incomplete pull requests
are caught before review, plus the `PULL_REQUEST_TEMPLATE.md` it validates
against (that file did not exist in the repo yet).

Closes #326

**What landed**

| Path | What it does |
| --- | --- |
| `.github/PULL_REQUEST_TEMPLATE.md` | New template: Summary, Testing done, Screenshots, and a Checklist referencing `CONTRIBUTING.md`'s branch / commit / CI rules. Hints are HTML comments so an unfilled section reads as empty. |
| `.github/scripts/check-pr-checklist.mjs` | The rules, as a pure function `checkPullRequest({ body, changedFiles, author, labels })` returning which required sections are missing. A thin CLI wrapper reads the webhook payload. |
| `.github/scripts/check-pr-checklist.test.mjs` | 20 unit tests, `node --test`, no new dependency. |
| `.github/workflows/pr-checklist.yml` | Runs the unit tests, then validates the PR description. |
| `.github/workflows/README.md` | Documents the new workflow, the bypass, and the fork-safety rationale alongside the three existing pipelines. |

**Required sections** — `## Summary`, `## Testing done`, `## Checklist` (with at
least one `- [x]` ticked). `## Screenshots` is required only when the diff
touches UI files (`apps/frontend/**`, `*.tsx`, `*.jsx`, `*.css`, `*.scss`,
`*.svg`). Heading aliases (`Test plan`, `Overview`, …), emoji decoration and
`###` levels are accepted; headings inside fenced code blocks are not.

**Actionable failure** — the job fails with a `::error::` annotation per missing
item plus a job summary naming each one and how to fix it, e.g.
`Summary — missing the "## Summary" section.` It fails rather than posting a bot
comment on purpose: commenting needs `pull-requests: write`, which fork PRs
cannot have under `pull_request` (see below).

**Bypass (documented in the workflow, the template and the README)** — the
maintainer-applied `skip-checklist` label, or a bot author (`dependabot[bot]`,
`github-actions[bot]`, `renovate[bot]`, or any `*[bot]` login). `labeled` /
`unlabeled` are trigger types so the label takes effect immediately instead of
waiting for the next push.

**Fork PR safety — why `pull_request`, not `pull_request_target`** — the
workflow executes contributor-authored code from the PR head. Under
`pull_request`, GitHub gives a fork PR a **read-only `GITHUB_TOKEN` and no
repository secrets**, so there is nothing privileged in scope to exfiltrate; the
job also declares `permissions: contents: read`. `pull_request_target` would
grant a write token and secrets while running against a ref the contributor
controls, and validating a description needs neither. The PR body is untrusted
input and is never interpolated into a shell command via `${{ … }}` — the
validator reads it from `GITHUB_EVENT_PATH` on disk, which sidesteps script
injection. No secret is ever read or echoed. This rationale is written both in a
comment block at the top of the workflow and in `.github/workflows/README.md`.

**Deviations from the issue's file list** — two additions, both in service of
the testing requirements: `.github/scripts/` (so the logic is a pure, unit-
tested function rather than inline YAML), and a documentation section in the
existing `.github/workflows/README.md` so the repo's CI docs stay accurate.

**Note on triggering** — per the design of this check, `pr-checklist.yml` is
deliberately **not** path-filtered like `frontend.yml` / `backend.yml` /
`contracts.yml`: it must validate every PR regardless of which files changed.
This also means it is self-validating — it runs against this very PR, and this
description is what it is checking.

## Testing done

Locally, on this branch:

- `node --test '.github/scripts/*.test.mjs'` — **20/20 pass**. Covers a fully
  valid body, a body missing Summary, a body missing Testing done, an empty
  body, a `null`/absent body, an unfilled-template body, a Checklist with no
  ticked box, heading aliases + emoji, headings inside fenced code blocks, the
  conditional Screenshots rule (UI vs non-UI diff), `isUiFile`, the
  `skip-checklist` label (string and label-object, case-insensitive), bot
  authors, a human author with an unrelated label, both report formats,
  `normalizeHeading`, `parseSections`, and CRLF bodies.
  (A directory argument is not accepted by Node 22's runner, hence the glob.)
- End-to-end CLI run against fixture webhook payloads:
  - incomplete body → exit **1**, three `::error::` annotations naming Summary,
    Testing done and Checklist;
  - valid body → exit **0**, "All required sections are present";
  - `dependabot[bot]` author with an empty body → exit **0**, "Skipped — the
    author is an automation account";
  - no `pull_request` payload (e.g. `workflow_dispatch`) → exit **0**, no-op.
- Workflow YAML parsed with `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pr-checklist.yml'))"` — triggers, permissions and all five steps resolve as intended.
In real GitHub Actions CI — because a first-time fork contributor's run here sits
in `action_required` until a maintainer approves it, I ran the workflow
end-to-end on the same branch in my fork
([emteebug12-jpg/chenaikit#1](https://github.com/emteebug12-jpg/chenaikit/pull/1),
now closed; it existed only as a test harness):

| Scenario | Run | Result |
| --- | --- | --- |
| Incomplete PR body | [32583090938](https://github.com/emteebug12-jpg/chenaikit/actions/runs/32583090938) | **fail**, exit 1, three `##[error]` annotations naming Summary / Testing done / Checklist |
| Body edited to this description (`edited` trigger) | [32583148275](https://github.com/emteebug12-jpg/chenaikit/actions/runs/32583148275) | **pass** — "All required sections are present" |
| Incomplete body + `skip-checklist` label (`labeled` trigger) | [32583191720](https://github.com/emteebug12-jpg/chenaikit/actions/runs/32583191720) | **pass** — `Skipped — the "skip-checklist" label is applied.` |

The unit-test step reported `# tests 20 / # pass 20 / # fail 0` in each run, and
the `Collect changed files` step correctly produced the five changed paths from
the shallow clone (which is what drives the conditional Screenshots rule).

Also: this PR itself exercises both steps once a maintainer approves the run.

## Screenshots

N/A — CI/tooling change only, no UI surface. The diff touches `.github/**`
exclusively, so `frontend.yml`, `backend.yml` and `contracts.yml` do not trigger
on this PR by design (they are path-filtered).

## Checklist

- [x] Branch follows the naming convention (`feat/pr-checklist-validation`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(ci): add pull request checklist validation`)
- [x] The PR is scoped to one issue, with no unrelated churn
- [x] All CI checks are green (see the CI requirements in `CONTRIBUTING.md`)
- [x] Docs updated where behavior changed (`.github/workflows/README.md`)
- [x] Screenshots attached for UI changes — N/A, no UI change
