### PR TITLE
docs(ml): document ML pipeline data contracts

### DIFF
--- a/ml/README.md
+++ b/ml/README.md
@@ -2,3 +2,336 @@
 
 Python ML pipeline. Scope unchanged from the pre-migration `ml/` — re-audit
 contents during the restructure but no relocation planned.
+
+---
+
+# ML pipeline data contract
+
+This document is the reference for everything that crosses the boundary between
+the Python pipeline in this directory and the TypeScript services that consume
+its output. Two payloads cross that boundary:
+
+| Direction | Payload | Contract | Version |
+| --- | --- | --- | --- |
+| **In** — feature store → model | `FeatureVector` | one scored subject | `1.0.0` |
+| **Out** — model → API / Soroban | `ModelResult` | one model verdict | `1.0.0` |
+
+Both are **JSON objects**, one per subject, newline-delimited when batched.
+
+The contract is not prose-only. The machine-readable half lives in
+[`packages/chenai-mlflow/src/index.ts`](../packages/chenai-mlflow/src/index.ts)
+as exported TypeScript types plus validators that enforce every rule described
+below, and it is exercised by
+[`packages/chenai-mlflow/src/index.test.ts`](../packages/chenai-mlflow/src/index.test.ts).
+**When this document and that module disagree, the module wins** — it is what
+actually rejects bad payloads at runtime. Amend both together.
+
+```ts
+import {
+  validateFeatureVector,   // throws SchemaValidationError, returns FeatureVector
+  isFeatureVector,         // non-throwing type guard
+  imputeFeatureVector,     // validate, then apply the missing-value policy
+  validateModelResult,
+  isModelResult,
+  NUMERIC_FEATURE_SPECS,   // the field table below, as data
+  EXAMPLE_FEATURE_VECTOR,
+  EXAMPLE_MODEL_RESULT,
+} from "@chenaikit/chenai-mlflow";
+```
+
+## Pipeline inventory
+
+```
+Stellar Horizon / ingest  ──▶  feature builder  ──▶  FeatureVector  (contract, versioned)
+                                                          │
+                                                    imputeFeatureVector
+                                                          │
+                                                          ▼
+                                                   model (credit-score | fraud-detect)
+                                                          │
+                                                          ▼
+                                                    ModelResult  (contract, versioned)
+                                                          │
+                                        ┌─────────────────┴─────────────────┐
+                                        ▼                                   ▼
+                              apps/backend API                  Soroban: contracts/credit-score,
+                                                                contracts/fraud-detect
+```
+
+Two model heads share both contracts, distinguished by `ModelResult.task`:
+
+- `credit-score` — creditworthiness of an account, mirroring
+  `contracts/credit-score`.
+- `fraud-detect` — anomaly risk of an account or a single payment, mirroring
+  `contracts/fraud-detect`.
+
+## Conventions that apply to every field
+
+- **Timestamps** are ISO-8601 in **UTC**, always ending in `Z`, with optional
+  milliseconds: `2026-01-15T00:00:00.000Z`. Local offsets such as `+01:00` are
+  rejected outright rather than normalised, so that no ambiguity survives into
+  training data.
+- **Money** is expressed in **stroops** — integers, never decimals.
+  `1 XLM = 10_000_000 stroops` (exported as `STROOPS_PER_XLM`). Amounts must
+  stay within `Number.MAX_SAFE_INTEGER`; a producer holding a larger value must
+  fail rather than round.
+- **Ratios** are floats in the closed interval `[0, 1]`, not percentages.
+- **Counts** are non-negative integers.
+- **`subjectId`** is an opaque pseudonymous identifier matching
+  `[A-Za-z0-9_-]{1,128}`. It must never carry personal data. The pattern is
+  itself a safeguard: it rejects email addresses and anything else containing
+  `@`, `.`, or whitespace.
+- **Unknown fields are rejected.** A payload carrying a key the contract does
+  not define is a version mismatch, and silently ignoring it would let a
+  producer believe it is sending a signal that no model reads.
+
+## Input: `FeatureVector`
+
+### Identity and provenance
+
+| Field | Type | Unit | Nullable | Notes |
+| --- | --- | --- | --- | --- |
+| `schemaVersion` | `string` | semver | no | Must equal the version this build implements (`1.0.0`). A payload from a future schema is rejected, not best-effort parsed. |
+| `subjectId` | `string` | — | no | Opaque pseudonymous id, `[A-Za-z0-9_-]{1,128}`. |
+| `subjectKind` | `"account" \| "transaction"` | — | no | What `subjectId` names. |
+| `observedAt` | `string` | ISO-8601 UTC | no | The instant the features are computed *as of*. All trailing windows below end here. |
+| `kycTier` | `0 \| 1 \| 2 \| 3` | tier | no | Customer due-diligence level. **Deliberately not nullable** — the caller always knows what it has on file, and "unverified" is precisely what tier `0` means. A `null` here would be indistinguishable from tier `0` while carrying different intent. |
+
+### Numeric features
+
+All nine are `number | null`. Each row's bounds and default are the same values
+the validator enforces — they come from the exported `NUMERIC_FEATURE_SPECS`
+table, so the documentation and the code cannot drift.
+
+| Field | Unit | Type | Range | Missing → | Meaning |
+| --- | --- | --- | --- | --- | --- |
+| `accountAgeDays` | days | integer | `0 … 36500` | `0` | Whole days between account creation and `observedAt`. |
+| `transactionCount30d` | count | integer | `0 … 1e9` | `0` | Settled payments in the trailing 30 days. |
+| `averageBalanceStroops` | stroops | integer | `0 … 2^53-1` | `0` | Time-weighted mean native balance over the trailing 30 days. |
+| `largestTransferStroops` | stroops | integer | `0 … 2^53-1` | `0` | Largest single outbound payment in the trailing 30 days. |
+| `distinctCounterparties30d` | count | integer | `0 … 1e9` | `0` | Distinct counterparty accounts in the trailing 30 days. |
+| `failedPaymentCount90d` | count | integer | `0 … 1e9` | `0` | Payments that failed or were reverted in the trailing 90 days. |
+| `disputeRatio90d` | ratio | float | `0 … 1` | `0` | Disputed ÷ total payments over the trailing 90 days. |
+| `crossBorderTransferRatio30d` | ratio | float | `0 … 1` | `0` | Share of 30-day payment volume whose counterparty anchor is in another jurisdiction. |
+| `medianSettlementLatencySeconds` | seconds | float | `0 … 2592000` | **`86400`** | Median seconds from submission to ledger close over the trailing 30 days. |
+
+### Missing-value behaviour
+
+The rules below are enforced by `validateFeatureVector` and
+`imputeFeatureVector`, not merely recommended.
+
+1. **`null` means "the upstream source had no value."** It is the only way to
+   express missing data.
+2. **The key must still be present.** An absent key is a producer bug — it
+   means the builder never considered the field — and is rejected with
+   `"<field> is required; use an explicit null to signal a missing value"`.
+   Treating absence as `null` would let a partially-implemented feature builder
+   silently ship vectors that look complete.
+3. **`undefined` is rejected** for the same reason, so a payload cannot lose
+   the distinction by round-tripping through a language that conflates the two.
+   Note that `JSON.stringify` drops `undefined` values, which turns rule 3 into
+   rule 2 on the wire — both are rejections.
+4. **Imputation happens in exactly one place:** `imputeFeatureVector`. It
+   validates, replaces each `null` with that field's documented default, and
+   returns an `ImputedFeatureVector` whose `imputedFields` array names every
+   field it filled. Models consume the imputed vector; nothing else is allowed
+   to invent values.
+5. **Defaults lean risk-averse, not mechanically toward zero.** Most unknowns
+   default to `0` because zero *is* the conservative reading — an account of
+   unknown age is treated as brand new, unknown balance as no balance.
+   `medianSettlementLatencySeconds` is the exception: `0` would assert instant
+   settlement, the most *favourable* possible value, so unknown latency imputes
+   to one day (`86400`).
+6. **`imputedFields` is carried through to the output** so that a consumer, and
+   any downstream Soroban contract, can tell a confident score from one built
+   partly on defaults.
+
+### Invalid-data behaviour
+
+`validateFeatureVector` throws `SchemaValidationError`, whose `issues` array
+lists **every** violation found — not just the first — so a broken producer can
+be fixed in one pass. Rejected, specifically:
+
+- a payload that is not a plain object (arrays, `null`, primitives);
+- an unknown field name;
+- a `schemaVersion` that is not semver, or that this build does not implement;
+- a `subjectId` that does not match the opaque-id pattern (this is what catches
+  personal data leaking into the id);
+- an `observedAt` that is not UTC ISO-8601, or is not a real calendar instant;
+- `NaN` or `Infinity` in any numeric field — these are never "missing", they
+  are a computation that went wrong upstream, and they must not be laundered
+  into a default;
+- a fractional value in an integer field, or a numeric value supplied as a
+  string;
+- any value outside its documented range, including negative counts and
+  amounts, and ratios above `1`.
+
+There is no lenient or coercing mode. A caller that wants a boolean instead of
+an exception uses the `isFeatureVector` type guard.
+
+### Example — complete
+
+```json
+{
+  "schemaVersion": "1.0.0",
+  "subjectId": "synthetic-account-0001",
+  "subjectKind": "account",
+  "observedAt": "2026-01-15T00:00:00.000Z",
+  "kycTier": 2,
+  "accountAgeDays": 418,
+  "transactionCount30d": 37,
+  "averageBalanceStroops": 1250000000,
+  "largestTransferStroops": 400000000,
+  "distinctCounterparties30d": 12,
+  "failedPaymentCount90d": 1,
+  "disputeRatio90d": 0.0,
+  "crossBorderTransferRatio30d": 0.24,
+  "medianSettlementLatencySeconds": 5.4
+}
+```
+
+`averageBalanceStroops: 1250000000` is 125 XLM; `largestTransferStroops:
+400000000` is 40 XLM.
+
+### Example — with missing values
+
+Three upstream sources were unavailable, so those fields are explicitly `null`:
+
+```json
+{
+  "schemaVersion": "1.0.0",
+  "subjectId": "synthetic-account-0002",
+  "subjectKind": "account",
+  "observedAt": "2026-01-15T00:00:00.000Z",
+  "kycTier": 0,
+  "accountAgeDays": null,
+  "transactionCount30d": 2,
+  "averageBalanceStroops": null,
+  "largestTransferStroops": 90000000,
+  "distinctCounterparties30d": 2,
+  "failedPaymentCount90d": 0,
+  "disputeRatio90d": 0.0,
+  "crossBorderTransferRatio30d": 1.0,
+  "medianSettlementLatencySeconds": null
+}
+```
+
+Passing this through `imputeFeatureVector` yields `accountAgeDays: 0`,
+`averageBalanceStroops: 0`, `medianSettlementLatencySeconds: 86400`, and
+`imputedFields: ["accountAgeDays", "averageBalanceStroops",
+"medianSettlementLatencySeconds"]`.
+
+Both examples are exported as `EXAMPLE_FEATURE_VECTOR` and
+`EXAMPLE_FEATURE_VECTOR_WITH_GAPS`, and the test suite asserts that they
+validate — so a documented example that stops being valid fails CI.
+
+## Output: `ModelResult`
+
+| Field | Type | Unit | Nullable | Notes |
+| --- | --- | --- | --- | --- |
+| `schemaVersion` | `string` | semver | no | Version of *this* contract (`1.0.0`). |
+| `modelId` | `string` | — | no | Stable model identifier, `[A-Za-z0-9._-]{1,128}`, e.g. `credit-score-gbm`. |
+| `modelVersion` | `string` | semver | no | Version of the trained artifact. `"latest"` and other floating tags are rejected — a score must be reproducible. |
+| `featureVectorVersion` | `string` | semver | no | `schemaVersion` of the input that was scored. |
+| `task` | `"credit-score" \| "fraud-detect"` | — | no | Which head produced the result. |
+| `subjectId` | `string` | — | no | Echoes the input's `subjectId`. |
+| `scoredAt` | `string` | ISO-8601 UTC | no | When the score was produced (distinct from `observedAt`, which is when the features were measured). |
+| `score` | `number` | ratio | no | Continuous risk score in `[0, 1]`; **higher = riskier**, for both tasks. |
+| `label` | `"low" \| "medium" \| "high"` | — | no | Discrete bucket from the model's calibrated thresholds. Consumers that need a class must read `label` rather than re-thresholding `score`, so that recalibration stays inside the model. |
+| `confidence` | `number` | ratio | no | Calibrated confidence in `label`, in `[0, 1]`. Independent of `score`: a confidently low-risk subject is `score: 0.05, confidence: 0.95`. |
+| `imputedFields` | `string[]` | — | no | Names of input features that were imputed. `[]` when the input was complete. Every entry must be a known feature name. |
+
+### Missing and invalid data on the output side
+
+**No field of `ModelResult` is nullable, and there is no partial result.** A
+model that cannot score a subject emits nothing at all and records the failure
+out of band. This is deliberate: the downstream consumers include Soroban
+contracts, which cannot distinguish "unknown" from "benign" — a `null` score
+arriving on-chain would be read as an absence of risk.
+
+`imputedFields` must be present even when empty. Omitting it is rejected,
+because an absent array and an empty array would otherwise both read as "nothing
+was imputed", and only one of them actually means that.
+
+`validateModelResult` rejects, again reporting every issue at once: unknown
+fields, a `schemaVersion` this build does not implement, non-semver versions, a
+`score` or `confidence` outside `[0, 1]`, an unrecognised `task` or `label`, a
+`subjectId` that could carry personal data, a malformed `scoredAt`, and any
+`imputedFields` entry that is not a defined feature name.
+
+### Example
+
+```json
+{
+  "schemaVersion": "1.0.0",
+  "modelId": "credit-score-gbm",
+  "modelVersion": "2.3.1",
+  "featureVectorVersion": "1.0.0",
+  "task": "credit-score",
+  "subjectId": "synthetic-account-0001",
+  "scoredAt": "2026-01-15T00:00:03.412Z",
+  "score": 0.17,
+  "label": "low",
+  "confidence": 0.91,
+  "imputedFields": []
+}
+```
+
+And the result for the vector with gaps, reporting what it had to fill in:
+
+```json
+{
+  "schemaVersion": "1.0.0",
+  "modelId": "fraud-detect-iforest",
+  "modelVersion": "0.9.0",
+  "featureVectorVersion": "1.0.0",
+  "task": "fraud-detect",
+  "subjectId": "synthetic-account-0002",
+  "scoredAt": "2026-01-15T00:00:03.907Z",
+  "score": 0.78,
+  "label": "high",
+  "confidence": 0.62,
+  "imputedFields": [
+    "accountAgeDays",
+    "averageBalanceStroops",
+    "medianSettlementLatencySeconds"
+  ]
+}
+```
+
+Exported as `EXAMPLE_MODEL_RESULT` and
+`EXAMPLE_MODEL_RESULT_WITH_IMPUTATION`.
+
+## All example data is synthetic
+
+Every value in this document and in the exported examples was fabricated by
+hand. The `subjectId`s are literal placeholders (`synthetic-account-0001`), not
+hashes or obfuscations of anything real; no field derives from a real account,
+person, or ledger entry. The test suite asserts that every exported example's
+`subjectId` begins with `synthetic-`, so a real identifier cannot be pasted in
+without failing CI.
+
+Contributors adding examples must keep them fabricated. Real production values
+do not belong in this repository even when the identifiers look opaque.
+
+## Versioning
+
+`FeatureVector` and `ModelResult` are versioned independently, both semver:
+
+- **patch** — documentation or wording only, no change to accepted payloads;
+- **minor** — a new *nullable* field, or a widened range: producers on the older
+  version stay valid;
+- **major** — anything else: a removed or renamed field, a narrowed range, a new
+  required field, or a changed imputation default.
+
+Because a validator rejects any `schemaVersion` it does not implement, a bump
+requires updating `FEATURE_VECTOR_SCHEMA_VERSION` /
+`MODEL_RESULT_SCHEMA_VERSION`, the examples, this document, and the tests in the
+same change.
+
+## Verifying the contract
+
+```bash
+pnpm --filter @chenaikit/chenai-mlflow run build   # tsc -p tsconfig.json
+pnpm --filter @chenaikit/chenai-mlflow run test    # vitest run
+```

--- a/packages/chenai-mlflow/src/index.test.ts
+++ b/packages/chenai-mlflow/src/index.test.ts
@@ -1,0 +1,317 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  EXAMPLE_FEATURE_VECTOR,
+  EXAMPLE_FEATURE_VECTOR_WITH_GAPS,
+  EXAMPLE_MODEL_RESULT,
+  EXAMPLE_MODEL_RESULT_WITH_IMPUTATION,
+  FEATURE_VECTOR_SCHEMA_VERSION,
+  MODEL_RESULT_SCHEMA_VERSION,
+  NUMERIC_FEATURE_SPECS,
+  SchemaValidationError,
+  imputeFeatureVector,
+  isFeatureVector,
+  isModelResult,
+  validateFeatureVector,
+  validateModelResult,
+} from "./index.js";
+
+/** Clone the good example and override one field, to isolate a single rule. */
+function featureVectorWith(
+  overrides: Record<string, unknown>,
+): Record<string, unknown> {
+  return { ...EXAMPLE_FEATURE_VECTOR, ...overrides };
+}
+
+function modelResultWith(
+  overrides: Record<string, unknown>,
+): Record<string, unknown> {
+  return { ...EXAMPLE_MODEL_RESULT, ...overrides };
+}
+
+describe("documented examples", () => {
+  it("accepts the fully populated feature vector example", () => {
+    expect(validateFeatureVector(EXAMPLE_FEATURE_VECTOR)).toEqual(
+      EXAMPLE_FEATURE_VECTOR,
+    );
+    expect(isFeatureVector(EXAMPLE_FEATURE_VECTOR)).toBe(true);
+  });
+
+  it("accepts the feature vector example that carries explicit nulls", () => {
+    expect(isFeatureVector(EXAMPLE_FEATURE_VECTOR_WITH_GAPS)).toBe(true);
+  });
+
+  it("accepts both model result examples", () => {
+    expect(validateModelResult(EXAMPLE_MODEL_RESULT)).toEqual(
+      EXAMPLE_MODEL_RESULT,
+    );
+    expect(isModelResult(EXAMPLE_MODEL_RESULT_WITH_IMPUTATION)).toBe(true);
+  });
+
+  it("survives a JSON round trip, since the wire format is JSON", () => {
+    const roundTripped: unknown = JSON.parse(
+      JSON.stringify(EXAMPLE_FEATURE_VECTOR_WITH_GAPS),
+    );
+    expect(isFeatureVector(roundTripped)).toBe(true);
+  });
+
+  it("uses only obviously synthetic subject ids", () => {
+    for (const example of [
+      EXAMPLE_FEATURE_VECTOR,
+      EXAMPLE_FEATURE_VECTOR_WITH_GAPS,
+      EXAMPLE_MODEL_RESULT,
+      EXAMPLE_MODEL_RESULT_WITH_IMPUTATION,
+    ]) {
+      expect(example.subjectId).toMatch(/^synthetic-/);
+    }
+  });
+
+  it("pins the examples to the schema versions this build implements", () => {
+    expect(EXAMPLE_FEATURE_VECTOR.schemaVersion).toBe(
+      FEATURE_VECTOR_SCHEMA_VERSION,
+    );
+    expect(EXAMPLE_MODEL_RESULT.schemaVersion).toBe(
+      MODEL_RESULT_SCHEMA_VERSION,
+    );
+    expect(EXAMPLE_MODEL_RESULT.featureVectorVersion).toBe(
+      FEATURE_VECTOR_SCHEMA_VERSION,
+    );
+  });
+});
+
+describe("validateFeatureVector — structural rules", () => {
+  it.each([
+    ["null", null],
+    ["an array", []],
+    ["a string", "{}"],
+    ["a number", 7],
+  ])("rejects %s as a payload", (_label, payload) => {
+    expect(() => validateFeatureVector(payload)).toThrow(SchemaValidationError);
+  });
+
+  it("rejects an absent field rather than treating it as missing data", () => {
+    const { accountAgeDays: _omitted, ...withoutField } =
+      EXAMPLE_FEATURE_VECTOR;
+    expect(() => validateFeatureVector(withoutField)).toThrow(
+      /accountAgeDays is required; use an explicit null/,
+    );
+  });
+
+  it("rejects undefined in place of an explicit null", () => {
+    expect(() =>
+      validateFeatureVector(featureVectorWith({ accountAgeDays: undefined })),
+    ).toThrow(/must not be undefined/);
+  });
+
+  it("rejects unknown fields", () => {
+    expect(() =>
+      validateFeatureVector(featureVectorWith({ shoeSize: 42 })),
+    ).toThrow(/unknown field "shoeSize"/);
+  });
+
+  it("reports every violation at once, not just the first", () => {
+    let caught: SchemaValidationError | undefined;
+    try {
+      validateFeatureVector(
+        featureVectorWith({
+          subjectId: "",
+          kycTier: 9,
+          disputeRatio90d: 4,
+        }),
+      );
+    } catch (error) {
+      caught = error as SchemaValidationError;
+    }
+    expect(caught).toBeInstanceOf(SchemaValidationError);
+    expect(caught?.schema).toBe("FeatureVector");
+    expect(caught?.issues).toHaveLength(3);
+  });
+});
+
+describe("validateFeatureVector — field rules", () => {
+  it("rejects a schemaVersion this build does not implement", () => {
+    expect(() =>
+      validateFeatureVector(featureVectorWith({ schemaVersion: "2.0.0" })),
+    ).toThrow(/is not supported by this build/);
+  });
+
+  it("rejects a subjectId that looks like personal data", () => {
+    expect(() =>
+      validateFeatureVector(
+        featureVectorWith({ subjectId: "ada.lovelace@example.com" }),
+      ),
+    ).toThrow(/must not carry personal data/);
+  });
+
+  it("rejects a non-UTC or malformed observedAt", () => {
+    for (const bad of [
+      "2026-01-15T00:00:00+01:00",
+      "2026-01-15",
+      "15/01/2026",
+      "2026-13-40T00:00:00.000Z",
+    ]) {
+      expect(() =>
+        validateFeatureVector(featureVectorWith({ observedAt: bad })),
+      ).toThrow(SchemaValidationError);
+    }
+  });
+
+  it("requires kycTier and rejects null for it", () => {
+    expect(() =>
+      validateFeatureVector(featureVectorWith({ kycTier: null })),
+    ).toThrow(/kycTier must be one of/);
+  });
+
+  it("rejects NaN and Infinity in numeric features", () => {
+    for (const bad of [Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(() =>
+        validateFeatureVector(featureVectorWith({ transactionCount30d: bad })),
+      ).toThrow(/must be a finite number or null/);
+    }
+  });
+
+  it("rejects a fractional value in an integer field", () => {
+    expect(() =>
+      validateFeatureVector(featureVectorWith({ transactionCount30d: 3.5 })),
+    ).toThrow(/must be an integer/);
+  });
+
+  it("allows a fractional value in a non-integer field", () => {
+    expect(
+      isFeatureVector(featureVectorWith({ disputeRatio90d: 0.125 })),
+    ).toBe(true);
+  });
+
+  it("rejects a ratio outside [0, 1]", () => {
+    expect(() =>
+      validateFeatureVector(featureVectorWith({ disputeRatio90d: 1.5 })),
+    ).toThrow(/must be within \[0, 1\]/);
+  });
+
+  it("rejects negative counts and amounts", () => {
+    expect(() =>
+      validateFeatureVector(
+        featureVectorWith({ averageBalanceStroops: -1 }),
+      ),
+    ).toThrow(/must be within/);
+  });
+
+  it("rejects a numeric feature supplied as a numeric string", () => {
+    expect(() =>
+      validateFeatureVector(featureVectorWith({ accountAgeDays: "418" })),
+    ).toThrow(/must be a finite number or null/);
+  });
+
+  it("accepts every numeric feature at both of its documented bounds", () => {
+    for (const spec of NUMERIC_FEATURE_SPECS) {
+      for (const bound of [spec.min, spec.max]) {
+        expect(isFeatureVector(featureVectorWith({ [spec.name]: bound }))).toBe(
+          true,
+        );
+      }
+    }
+  });
+
+  it("accepts null for every numeric feature", () => {
+    for (const spec of NUMERIC_FEATURE_SPECS) {
+      expect(isFeatureVector(featureVectorWith({ [spec.name]: null }))).toBe(
+        true,
+      );
+    }
+  });
+});
+
+describe("imputeFeatureVector", () => {
+  it("leaves a complete vector untouched and reports nothing imputed", () => {
+    const imputed = imputeFeatureVector(EXAMPLE_FEATURE_VECTOR);
+    expect(imputed.imputedFields).toEqual([]);
+    expect(imputed.accountAgeDays).toBe(EXAMPLE_FEATURE_VECTOR.accountAgeDays);
+    expect(imputed.subjectId).toBe(EXAMPLE_FEATURE_VECTOR.subjectId);
+  });
+
+  it("fills nulls with the documented defaults and names the filled fields", () => {
+    const imputed = imputeFeatureVector(EXAMPLE_FEATURE_VECTOR_WITH_GAPS);
+    expect(imputed.imputedFields).toEqual([
+      "accountAgeDays",
+      "averageBalanceStroops",
+      "medianSettlementLatencySeconds",
+    ]);
+    expect(imputed.accountAgeDays).toBe(0);
+    expect(imputed.averageBalanceStroops).toBe(0);
+    // Unknown latency imputes to one day, deliberately not to zero.
+    expect(imputed.medianSettlementLatencySeconds).toBe(86_400);
+  });
+
+  it("matches the imputedFields reported by the paired model result example", () => {
+    const imputed = imputeFeatureVector(EXAMPLE_FEATURE_VECTOR_WITH_GAPS);
+    expect(imputed.imputedFields).toEqual(
+      EXAMPLE_MODEL_RESULT_WITH_IMPUTATION.imputedFields,
+    );
+  });
+
+  it("yields a number for every numeric feature", () => {
+    const imputed = imputeFeatureVector(EXAMPLE_FEATURE_VECTOR_WITH_GAPS);
+    for (const spec of NUMERIC_FEATURE_SPECS) {
+      expect(typeof imputed[spec.name]).toBe("number");
+    }
+  });
+
+  it("validates before imputing, so invalid input never reaches a model", () => {
+    expect(() =>
+      imputeFeatureVector(featureVectorWith({ disputeRatio90d: 42 })),
+    ).toThrow(SchemaValidationError);
+  });
+});
+
+describe("validateModelResult", () => {
+  it("rejects null anywhere — a result is complete or it does not exist", () => {
+    for (const field of ["score", "label", "confidence", "modelVersion"]) {
+      expect(() => validateModelResult(modelResultWith({ [field]: null }))).toThrow(
+        SchemaValidationError,
+      );
+    }
+  });
+
+  it("rejects a score or confidence outside [0, 1]", () => {
+    expect(() => validateModelResult(modelResultWith({ score: 1.01 }))).toThrow(
+      /score must be within \[0, 1\]/,
+    );
+    expect(() =>
+      validateModelResult(modelResultWith({ confidence: -0.1 })),
+    ).toThrow(/confidence must be within \[0, 1\]/);
+  });
+
+  it("rejects an unknown task or label", () => {
+    expect(() =>
+      validateModelResult(modelResultWith({ task: "sentiment" })),
+    ).toThrow(/task must be one of/);
+    expect(() =>
+      validateModelResult(modelResultWith({ label: "catastrophic" })),
+    ).toThrow(/label must be one of/);
+  });
+
+  it("rejects a non-semver modelVersion", () => {
+    expect(() =>
+      validateModelResult(modelResultWith({ modelVersion: "latest" })),
+    ).toThrow(/modelVersion must be a semver string/);
+  });
+
+  it("rejects imputedFields naming something that is not a feature", () => {
+    expect(() =>
+      validateModelResult(modelResultWith({ imputedFields: ["shoeSize"] })),
+    ).toThrow(/not a known feature name/);
+  });
+
+  it("requires imputedFields to be present as an empty array, not omitted", () => {
+    const { imputedFields: _omitted, ...withoutField } = EXAMPLE_MODEL_RESULT;
+    expect(() => validateModelResult(withoutField)).toThrow(
+      /imputedFields must be an array/,
+    );
+  });
+
+  it("rejects unknown fields", () => {
+    expect(() =>
+      validateModelResult(modelResultWith({ explanation: "because" })),
+    ).toThrow(/unknown field "explanation"/);
+  });
+});

--- a/packages/chenai-mlflow/src/index.ts
+++ b/packages/chenai-mlflow/src/index.ts
@@ -1,3 +1,704 @@
-// @chenaikit/chenai-mlflow — ML experiment tracking integration (placeholder)
+// @chenaikit/chenai-mlflow — ML experiment tracking integration.
+//
+// This module is the machine-readable half of the ML pipeline data contract.
+// The prose half — units, provenance and the rationale behind every
+// missing-value rule — lives in `ml/README.md`. The two are meant to be read
+// together: `ml/README.md` explains *why*, the specs below enforce *what*.
+
 export const VERSION = "0.1.0";
 
+/** Schema version of the {@link FeatureVector} contract (semver). */
+export const FEATURE_VECTOR_SCHEMA_VERSION = "1.0.0";
+
+/** Schema version of the {@link ModelResult} contract (semver). */
+export const MODEL_RESULT_SCHEMA_VERSION = "1.0.0";
+
+/**
+ * Stroops per XLM. All monetary feature fields are integer stroops so that no
+ * value in the pipeline ever depends on binary floating-point rounding.
+ */
+export const STROOPS_PER_XLM = 10_000_000;
+
+// ---------------------------------------------------------------------------
+// Feature vector (pipeline input)
+// ---------------------------------------------------------------------------
+
+/** What the feature vector describes: a Stellar account, or a single payment. */
+export type SubjectKind = "account" | "transaction";
+
+/**
+ * Customer due-diligence level known to the caller at feature-build time.
+ * `0` = unverified. This is never `null`: the caller always knows the tier it
+ * has on file, and "unverified" is exactly what tier `0` means.
+ */
+export type KycTier = 0 | 1 | 2 | 3;
+
+/** Names of the nullable numeric features. */
+export type NumericFeatureName =
+  | "accountAgeDays"
+  | "transactionCount30d"
+  | "averageBalanceStroops"
+  | "largestTransferStroops"
+  | "distinctCounterparties30d"
+  | "failedPaymentCount90d"
+  | "disputeRatio90d"
+  | "crossBorderTransferRatio30d"
+  | "medianSettlementLatencySeconds";
+
+/**
+ * Declarative spec for one numeric feature. The validator and the imputer are
+ * both driven off these records, so the documented contract and the enforced
+ * contract cannot drift apart.
+ */
+export interface NumericFeatureSpec {
+  /** Field name as it appears on {@link FeatureVector}. */
+  readonly name: NumericFeatureName;
+  /** Physical unit, for documentation and for downstream unit assertions. */
+  readonly unit: "days" | "count" | "stroops" | "ratio" | "seconds";
+  /** Whether the field must be an integer (counts and stroops) or may be fractional. */
+  readonly integer: boolean;
+  /** Inclusive lower bound. */
+  readonly min: number;
+  /** Inclusive upper bound. */
+  readonly max: number;
+  /** Value substituted by {@link imputeFeatureVector} when the field is `null`. */
+  readonly missingDefault: number;
+  /** Human-readable meaning, mirrored in `ml/README.md`. */
+  readonly description: string;
+}
+
+/**
+ * The nullable numeric features, in canonical order.
+ *
+ * Imputation defaults lean toward the risk-averse reading of "unknown" rather
+ * than mechanically toward zero — see `medianSettlementLatencySeconds`, where
+ * `0` would falsely claim instant settlement.
+ */
+export const NUMERIC_FEATURE_SPECS: readonly NumericFeatureSpec[] = [
+  {
+    name: "accountAgeDays",
+    unit: "days",
+    integer: true,
+    min: 0,
+    max: 36_500,
+    missingDefault: 0,
+    description:
+      "Whole days between account creation and observedAt. Unknown age is treated as a brand-new account.",
+  },
+  {
+    name: "transactionCount30d",
+    unit: "count",
+    integer: true,
+    min: 0,
+    max: 1_000_000_000,
+    missingDefault: 0,
+    description: "Settled payments in the 30 days ending at observedAt.",
+  },
+  {
+    name: "averageBalanceStroops",
+    unit: "stroops",
+    integer: true,
+    min: 0,
+    max: Number.MAX_SAFE_INTEGER,
+    missingDefault: 0,
+    description:
+      "Time-weighted mean native balance over the 30 days ending at observedAt, in stroops.",
+  },
+  {
+    name: "largestTransferStroops",
+    unit: "stroops",
+    integer: true,
+    min: 0,
+    max: Number.MAX_SAFE_INTEGER,
+    missingDefault: 0,
+    description:
+      "Largest single outbound payment in the 30 days ending at observedAt, in stroops.",
+  },
+  {
+    name: "distinctCounterparties30d",
+    unit: "count",
+    integer: true,
+    min: 0,
+    max: 1_000_000_000,
+    missingDefault: 0,
+    description:
+      "Distinct counterparty accounts transacted with in the 30 days ending at observedAt.",
+  },
+  {
+    name: "failedPaymentCount90d",
+    unit: "count",
+    integer: true,
+    min: 0,
+    max: 1_000_000_000,
+    missingDefault: 0,
+    description:
+      "Submitted payments that failed or were reverted in the 90 days ending at observedAt.",
+  },
+  {
+    name: "disputeRatio90d",
+    unit: "ratio",
+    integer: false,
+    min: 0,
+    max: 1,
+    missingDefault: 0,
+    description:
+      "Disputed payments divided by total payments over the 90 days ending at observedAt.",
+  },
+  {
+    name: "crossBorderTransferRatio30d",
+    unit: "ratio",
+    integer: false,
+    min: 0,
+    max: 1,
+    missingDefault: 0,
+    description:
+      "Share of 30-day payment volume whose counterparty anchor is in a different jurisdiction.",
+  },
+  {
+    name: "medianSettlementLatencySeconds",
+    unit: "seconds",
+    integer: false,
+    min: 0,
+    max: 2_592_000,
+    missingDefault: 86_400,
+    description:
+      "Median seconds from submission to ledger close over the 30 days ending at observedAt. Unknown latency imputes to one day, never to zero.",
+  },
+] as const;
+
+/**
+ * A single scored subject, as handed to a model.
+ *
+ * Missing-value convention: every numeric feature is `number | null`, where
+ * `null` means "the upstream source had no value". The key must still be
+ * present — an absent key is a producer bug and is rejected, not silently
+ * treated as `null`.
+ */
+export interface FeatureVector {
+  /** Semver of this contract; must equal {@link FEATURE_VECTOR_SCHEMA_VERSION}. */
+  schemaVersion: string;
+  /** Opaque pseudonymous identifier. `[A-Za-z0-9_-]{1,128}` — never PII. */
+  subjectId: string;
+  /** Whether `subjectId` names an account or a single payment. */
+  subjectKind: SubjectKind;
+  /** ISO-8601 UTC instant the features were computed as of, e.g. `2026-01-15T00:00:00.000Z`. */
+  observedAt: string;
+  /** Customer due-diligence tier. Required — see {@link KycTier}. */
+  kycTier: KycTier;
+
+  /** Whole days since account creation. Unit: days. `null` = unknown. */
+  accountAgeDays: number | null;
+  /** Settled payments in the trailing 30 days. Unit: count. `null` = unknown. */
+  transactionCount30d: number | null;
+  /** Time-weighted mean native balance. Unit: stroops. `null` = unknown. */
+  averageBalanceStroops: number | null;
+  /** Largest single outbound payment in 30 days. Unit: stroops. `null` = unknown. */
+  largestTransferStroops: number | null;
+  /** Distinct counterparties in 30 days. Unit: count. `null` = unknown. */
+  distinctCounterparties30d: number | null;
+  /** Failed or reverted payments in 90 days. Unit: count. `null` = unknown. */
+  failedPaymentCount90d: number | null;
+  /** Disputed / total payments over 90 days. Unit: ratio in [0,1]. `null` = unknown. */
+  disputeRatio90d: number | null;
+  /** Cross-border share of 30-day volume. Unit: ratio in [0,1]. `null` = unknown. */
+  crossBorderTransferRatio30d: number | null;
+  /** Median submit-to-close latency over 30 days. Unit: seconds. `null` = unknown. */
+  medianSettlementLatencySeconds: number | null;
+}
+
+/**
+ * A {@link FeatureVector} with every `null` replaced by its documented default.
+ * This — not the raw vector — is what a model consumes.
+ */
+export type ImputedFeatureVector = Omit<FeatureVector, NumericFeatureName> & {
+  readonly [K in NumericFeatureName]: number;
+} & {
+  /** Feature names that were `null` and have been filled with their default. */
+  readonly imputedFields: readonly NumericFeatureName[];
+};
+
+// ---------------------------------------------------------------------------
+// Model result (pipeline output)
+// ---------------------------------------------------------------------------
+
+/** Which head produced the result. Mirrors the Soroban contracts of the same name. */
+export type ModelTask = "credit-score" | "fraud-detect";
+
+/** Discrete class emitted alongside the continuous score. */
+export type RiskLabel = "low" | "medium" | "high";
+
+/**
+ * A model's verdict on one subject.
+ *
+ * No field is nullable. A model that cannot score a subject emits *no*
+ * `ModelResult` at all and records the failure out of band — a partially
+ * populated result must never reach the chain, because downstream Soroban
+ * contracts cannot distinguish "unknown" from "benign".
+ */
+export interface ModelResult {
+  /** Semver of this contract; must equal {@link MODEL_RESULT_SCHEMA_VERSION}. */
+  schemaVersion: string;
+  /** Stable model identifier, e.g. `credit-score-gbm`. `[A-Za-z0-9._-]{1,128}`. */
+  modelId: string;
+  /** Semver of the trained artifact that produced this result. */
+  modelVersion: string;
+  /** `schemaVersion` of the {@link FeatureVector} that was scored. */
+  featureVectorVersion: string;
+  /** Which head produced the result. */
+  task: ModelTask;
+  /** Echoes {@link FeatureVector.subjectId}. */
+  subjectId: string;
+  /** ISO-8601 UTC instant the score was produced. */
+  scoredAt: string;
+  /** Continuous risk score. Unit: ratio in [0,1]; higher = riskier. */
+  score: number;
+  /** Discrete bucket derived from `score` via the model's calibrated thresholds. */
+  label: RiskLabel;
+  /** Calibrated confidence in `label`. Unit: ratio in [0,1]. */
+  confidence: number;
+  /** Feature names that were imputed on the way in. Empty when nothing was missing. */
+  imputedFields: NumericFeatureName[];
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+/** Raised when a payload does not satisfy a documented contract. */
+export class SchemaValidationError extends Error {
+  /** Every violation found, not just the first. */
+  readonly issues: readonly string[];
+  /** Name of the contract that rejected the payload. */
+  readonly schema: string;
+
+  constructor(schema: string, issues: readonly string[]) {
+    super(`${schema} validation failed: ${issues.join("; ")}`);
+    this.name = "SchemaValidationError";
+    this.schema = schema;
+    this.issues = issues;
+    Object.setPrototypeOf(this, SchemaValidationError.prototype);
+  }
+}
+
+const SUBJECT_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+const MODEL_ID_PATTERN = /^[A-Za-z0-9._-]{1,128}$/;
+const SEMVER_PATTERN = /^\d+\.\d+\.\d+$/;
+const ISO_UTC_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?Z$/;
+
+const SUBJECT_KINDS: readonly SubjectKind[] = ["account", "transaction"];
+const KYC_TIERS: readonly KycTier[] = [0, 1, 2, 3];
+const MODEL_TASKS: readonly ModelTask[] = ["credit-score", "fraud-detect"];
+const RISK_LABELS: readonly RiskLabel[] = ["low", "medium", "high"];
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function checkTimestamp(
+  issues: string[],
+  record: Record<string, unknown>,
+  field: string,
+): void {
+  const value = record[field];
+  if (typeof value !== "string" || !ISO_UTC_PATTERN.test(value)) {
+    issues.push(`${field} must be an ISO-8601 UTC timestamp ending in "Z"`);
+    return;
+  }
+  if (Number.isNaN(Date.parse(value))) {
+    issues.push(`${field} is not a real calendar instant`);
+  }
+}
+
+function checkString(
+  issues: string[],
+  record: Record<string, unknown>,
+  field: string,
+  pattern: RegExp,
+  expectation: string,
+): void {
+  const value = record[field];
+  if (typeof value !== "string") {
+    issues.push(`${field} must be a string`);
+  } else if (!pattern.test(value)) {
+    issues.push(`${field} must ${expectation}`);
+  }
+}
+
+function checkEnum<T>(
+  issues: string[],
+  record: Record<string, unknown>,
+  field: string,
+  allowed: readonly T[],
+): void {
+  if (!allowed.includes(record[field] as T)) {
+    issues.push(
+      `${field} must be one of ${allowed.map((v) => JSON.stringify(v)).join(", ")}`,
+    );
+  }
+}
+
+function checkBoundedNumber(
+  issues: string[],
+  record: Record<string, unknown>,
+  field: string,
+  min: number,
+  max: number,
+): void {
+  const value = record[field];
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    issues.push(`${field} must be a finite number`);
+  } else if (value < min || value > max) {
+    issues.push(`${field} must be within [${min}, ${max}], got ${value}`);
+  }
+}
+
+/**
+ * Validate an untrusted payload against the {@link FeatureVector} contract.
+ *
+ * Rejects, with every issue listed: unknown or absent keys, `undefined` in
+ * place of an explicit `null`, `NaN`/`Infinity`, fractional values in integer
+ * fields, out-of-range values, a `subjectId` that looks like PII (anything
+ * outside `[A-Za-z0-9_-]`, which excludes emails and account addresses with
+ * punctuation), and a `schemaVersion` this build does not implement.
+ *
+ * @throws {SchemaValidationError}
+ */
+export function validateFeatureVector(input: unknown): FeatureVector {
+  const issues: string[] = [];
+
+  if (!isPlainObject(input)) {
+    throw new SchemaValidationError("FeatureVector", [
+      "payload must be a plain object",
+    ]);
+  }
+
+  const known = new Set<string>([
+    "schemaVersion",
+    "subjectId",
+    "subjectKind",
+    "observedAt",
+    "kycTier",
+    ...NUMERIC_FEATURE_SPECS.map((spec) => spec.name),
+  ]);
+  for (const key of Object.keys(input)) {
+    if (!known.has(key)) {
+      issues.push(`unknown field ${JSON.stringify(key)}`);
+    }
+  }
+
+  checkString(
+    issues,
+    input,
+    "schemaVersion",
+    SEMVER_PATTERN,
+    "be a semver string such as \"1.0.0\"",
+  );
+  if (
+    typeof input.schemaVersion === "string" &&
+    SEMVER_PATTERN.test(input.schemaVersion) &&
+    input.schemaVersion !== FEATURE_VECTOR_SCHEMA_VERSION
+  ) {
+    issues.push(
+      `schemaVersion ${input.schemaVersion} is not supported by this build (expected ${FEATURE_VECTOR_SCHEMA_VERSION})`,
+    );
+  }
+
+  checkString(
+    issues,
+    input,
+    "subjectId",
+    SUBJECT_ID_PATTERN,
+    "be an opaque pseudonymous id matching [A-Za-z0-9_-]{1,128} and must not carry personal data",
+  );
+  checkEnum(issues, input, "subjectKind", SUBJECT_KINDS);
+  checkTimestamp(issues, input, "observedAt");
+  checkEnum(issues, input, "kycTier", KYC_TIERS);
+
+  for (const spec of NUMERIC_FEATURE_SPECS) {
+    if (!Object.prototype.hasOwnProperty.call(input, spec.name)) {
+      issues.push(
+        `${spec.name} is required; use an explicit null to signal a missing value`,
+      );
+      continue;
+    }
+
+    const value = input[spec.name];
+    if (value === null) continue;
+
+    if (value === undefined) {
+      issues.push(
+        `${spec.name} must not be undefined; use an explicit null to signal a missing value`,
+      );
+      continue;
+    }
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+      issues.push(
+        `${spec.name} must be a finite number or null (unit: ${spec.unit})`,
+      );
+      continue;
+    }
+    if (spec.integer && !Number.isInteger(value)) {
+      issues.push(`${spec.name} must be an integer (unit: ${spec.unit})`);
+      continue;
+    }
+    if (value < spec.min || value > spec.max) {
+      issues.push(
+        `${spec.name} must be within [${spec.min}, ${spec.max}], got ${value}`,
+      );
+    }
+  }
+
+  if (issues.length > 0) {
+    throw new SchemaValidationError("FeatureVector", issues);
+  }
+  return input as unknown as FeatureVector;
+}
+
+/** Non-throwing type guard over {@link validateFeatureVector}. */
+export function isFeatureVector(input: unknown): input is FeatureVector {
+  try {
+    validateFeatureVector(input);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Validate an untrusted payload against the {@link ModelResult} contract.
+ *
+ * Nulls are rejected everywhere: an output is complete or it does not exist.
+ *
+ * @throws {SchemaValidationError}
+ */
+export function validateModelResult(input: unknown): ModelResult {
+  const issues: string[] = [];
+
+  if (!isPlainObject(input)) {
+    throw new SchemaValidationError("ModelResult", [
+      "payload must be a plain object",
+    ]);
+  }
+
+  const known = new Set<string>([
+    "schemaVersion",
+    "modelId",
+    "modelVersion",
+    "featureVectorVersion",
+    "task",
+    "subjectId",
+    "scoredAt",
+    "score",
+    "label",
+    "confidence",
+    "imputedFields",
+  ]);
+  for (const key of Object.keys(input)) {
+    if (!known.has(key)) {
+      issues.push(`unknown field ${JSON.stringify(key)}`);
+    }
+  }
+
+  checkString(
+    issues,
+    input,
+    "schemaVersion",
+    SEMVER_PATTERN,
+    "be a semver string such as \"1.0.0\"",
+  );
+  if (
+    typeof input.schemaVersion === "string" &&
+    SEMVER_PATTERN.test(input.schemaVersion) &&
+    input.schemaVersion !== MODEL_RESULT_SCHEMA_VERSION
+  ) {
+    issues.push(
+      `schemaVersion ${input.schemaVersion} is not supported by this build (expected ${MODEL_RESULT_SCHEMA_VERSION})`,
+    );
+  }
+
+  checkString(
+    issues,
+    input,
+    "modelId",
+    MODEL_ID_PATTERN,
+    "match [A-Za-z0-9._-]{1,128}",
+  );
+  checkString(
+    issues,
+    input,
+    "modelVersion",
+    SEMVER_PATTERN,
+    "be a semver string such as \"2.3.1\"",
+  );
+  checkString(
+    issues,
+    input,
+    "featureVectorVersion",
+    SEMVER_PATTERN,
+    "be a semver string such as \"1.0.0\"",
+  );
+  checkEnum(issues, input, "task", MODEL_TASKS);
+  checkString(
+    issues,
+    input,
+    "subjectId",
+    SUBJECT_ID_PATTERN,
+    "be an opaque pseudonymous id matching [A-Za-z0-9_-]{1,128} and must not carry personal data",
+  );
+  checkTimestamp(issues, input, "scoredAt");
+  checkBoundedNumber(issues, input, "score", 0, 1);
+  checkEnum(issues, input, "label", RISK_LABELS);
+  checkBoundedNumber(issues, input, "confidence", 0, 1);
+
+  const featureNames = new Set<string>(
+    NUMERIC_FEATURE_SPECS.map((spec) => spec.name),
+  );
+  const imputed = input.imputedFields;
+  if (!Array.isArray(imputed)) {
+    issues.push("imputedFields must be an array (empty when nothing was imputed)");
+  } else {
+    for (const name of imputed) {
+      if (typeof name !== "string" || !featureNames.has(name)) {
+        issues.push(
+          `imputedFields contains ${JSON.stringify(name)}, which is not a known feature name`,
+        );
+      }
+    }
+  }
+
+  if (issues.length > 0) {
+    throw new SchemaValidationError("ModelResult", issues);
+  }
+  return input as unknown as ModelResult;
+}
+
+/** Non-throwing type guard over {@link validateModelResult}. */
+export function isModelResult(input: unknown): input is ModelResult {
+  try {
+    validateModelResult(input);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Apply the documented missing-value policy: replace every `null` feature with
+ * its `missingDefault` and record which fields were filled in.
+ *
+ * The input is validated first, so this is the single supported way to turn an
+ * untrusted payload into something a model may consume.
+ *
+ * @throws {SchemaValidationError} if `input` is not a valid {@link FeatureVector}.
+ */
+export function imputeFeatureVector(input: unknown): ImputedFeatureVector {
+  const vector = validateFeatureVector(input);
+  const imputedFields: NumericFeatureName[] = [];
+  // Every NumericFeatureName is assigned in the loop below, one per spec.
+  const filled = {} as Record<NumericFeatureName, number>;
+
+  for (const spec of NUMERIC_FEATURE_SPECS) {
+    const value = vector[spec.name];
+    if (value === null) {
+      imputedFields.push(spec.name);
+      filled[spec.name] = spec.missingDefault;
+    } else {
+      filled[spec.name] = value;
+    }
+  }
+
+  return {
+    schemaVersion: vector.schemaVersion,
+    subjectId: vector.subjectId,
+    subjectKind: vector.subjectKind,
+    observedAt: vector.observedAt,
+    kycTier: vector.kycTier,
+    ...filled,
+    imputedFields,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Synthetic examples
+// ---------------------------------------------------------------------------
+//
+// Fabricated by hand for documentation and tests. `subjectId` values are
+// literal placeholders, not hashes of anything real, and no field derives from
+// a real account, person, or ledger entry.
+
+/** Synthetic {@link FeatureVector} with every field populated. */
+export const EXAMPLE_FEATURE_VECTOR: FeatureVector = {
+  schemaVersion: FEATURE_VECTOR_SCHEMA_VERSION,
+  subjectId: "synthetic-account-0001",
+  subjectKind: "account",
+  observedAt: "2026-01-15T00:00:00.000Z",
+  kycTier: 2,
+  accountAgeDays: 418,
+  transactionCount30d: 37,
+  averageBalanceStroops: 1_250_000_000, // 125 XLM
+  largestTransferStroops: 400_000_000, // 40 XLM
+  distinctCounterparties30d: 12,
+  failedPaymentCount90d: 1,
+  disputeRatio90d: 0.0,
+  crossBorderTransferRatio30d: 0.24,
+  medianSettlementLatencySeconds: 5.4,
+};
+
+/**
+ * Synthetic {@link FeatureVector} exercising the missing-value convention:
+ * three sources were unavailable, so those fields are explicitly `null`.
+ */
+export const EXAMPLE_FEATURE_VECTOR_WITH_GAPS: FeatureVector = {
+  schemaVersion: FEATURE_VECTOR_SCHEMA_VERSION,
+  subjectId: "synthetic-account-0002",
+  subjectKind: "account",
+  observedAt: "2026-01-15T00:00:00.000Z",
+  kycTier: 0,
+  accountAgeDays: null,
+  transactionCount30d: 2,
+  averageBalanceStroops: null,
+  largestTransferStroops: 90_000_000, // 9 XLM
+  distinctCounterparties30d: 2,
+  failedPaymentCount90d: 0,
+  disputeRatio90d: 0.0,
+  crossBorderTransferRatio30d: 1.0,
+  medianSettlementLatencySeconds: null,
+};
+
+/** Synthetic {@link ModelResult} corresponding to {@link EXAMPLE_FEATURE_VECTOR}. */
+export const EXAMPLE_MODEL_RESULT: ModelResult = {
+  schemaVersion: MODEL_RESULT_SCHEMA_VERSION,
+  modelId: "credit-score-gbm",
+  modelVersion: "2.3.1",
+  featureVectorVersion: FEATURE_VECTOR_SCHEMA_VERSION,
+  task: "credit-score",
+  subjectId: "synthetic-account-0001",
+  scoredAt: "2026-01-15T00:00:03.412Z",
+  score: 0.17,
+  label: "low",
+  confidence: 0.91,
+  imputedFields: [],
+};
+
+/**
+ * Synthetic {@link ModelResult} corresponding to
+ * {@link EXAMPLE_FEATURE_VECTOR_WITH_GAPS}: the same three fields that were
+ * `null` on the way in are reported back on the way out.
+ */
+export const EXAMPLE_MODEL_RESULT_WITH_IMPUTATION: ModelResult = {
+  schemaVersion: MODEL_RESULT_SCHEMA_VERSION,
+  modelId: "fraud-detect-iforest",
+  modelVersion: "0.9.0",
+  featureVectorVersion: FEATURE_VECTOR_SCHEMA_VERSION,
+  task: "fraud-detect",
+  subjectId: "synthetic-account-0002",
+  scoredAt: "2026-01-15T00:00:03.907Z",
+  score: 0.78,
+  label: "high",
+  confidence: 0.62,
+  imputedFields: [
+    "accountAgeDays",
+    "averageBalanceStroops",
+    "medianSettlementLatencySeconds",
+  ],
+};


### PR DESCRIPTION
Closes #328

## Summary

Documents the ML pipeline's input and output data contracts, and gives them a concrete, enforced TypeScript form so the documentation points at something real rather than describing an aspiration.

Both `ml/README.md` and `packages/chenai-mlflow/src/index.ts` were one-line placeholders, so this establishes the contract rather than describing pre-existing code.

**Two payloads cross the Python/TypeScript boundary**, both versioned independently (semver, currently `1.0.0`) and both JSON:

- **`FeatureVector`** (input) — one scored subject. Identity/provenance fields (`schemaVersion`, `subjectId`, `subjectKind`, `observedAt`, `kycTier`) plus nine nullable numeric features: `accountAgeDays`, `transactionCount30d`, `averageBalanceStroops`, `largestTransferStroops`, `distinctCounterparties30d`, `failedPaymentCount90d`, `disputeRatio90d`, `crossBorderTransferRatio30d`, `medianSettlementLatencySeconds`.
- **`ModelResult`** (output) — one model verdict: `modelId`, `modelVersion`, `featureVectorVersion`, `task` (`credit-score` | `fraud-detect`, mirroring the Soroban contracts of the same name), `subjectId`, `scoredAt`, `score` (`[0,1]`, higher = riskier), `label`, `confidence`, and `imputedFields`.

**Conventions fixed across the contract:** timestamps are UTC ISO-8601 ending in `Z` (local offsets are rejected, not normalised); money is integer **stroops**, never decimals; ratios are floats in `[0,1]`; `subjectId` is an opaque pseudonymous id matching `[A-Za-z0-9_-]{1,128}`, a pattern which itself rejects email addresses and other PII-shaped values.

**Missing-value behaviour is enforced by the validator, not just prose:**

- `null` is the only way to express missing data.
- An **absent key** or `undefined` is rejected as a producer bug — treating absence as `null` would let a half-implemented feature builder ship vectors that look complete.
- `NaN`/`Infinity` are rejected rather than laundered into a default: they mean an upstream computation went wrong, not that data is missing.
- Imputation happens in exactly one place, `imputeFeatureVector`, which returns an `ImputedFeatureVector` naming every field it filled — and that list is carried through to `ModelResult.imputedFields` so a consumer can tell a confident score from one built partly on defaults.
- Defaults lean risk-averse rather than mechanically toward zero. Most unknowns default to `0` because zero *is* the conservative reading, but `medianSettlementLatencySeconds` defaults to `86400`, since `0` would assert instant settlement — the most favourable possible value.
- `ModelResult` has **no** nullable fields: a model that cannot score a subject emits nothing at all. The consumers include Soroban contracts, which cannot distinguish "unknown" from "benign", so a `null` score arriving on-chain would read as an absence of risk.

**Single source of truth:** the exported `NUMERIC_FEATURE_SPECS` table (unit, integer-ness, bounds, imputation default, description) drives both the validator and the imputer, and the field table in `ml/README.md` mirrors it — so the documented contract and the enforced contract cannot silently drift apart.

**API added to `@chenaikit/chenai-mlflow`:** `validateFeatureVector` / `isFeatureVector`, `validateModelResult` / `isModelResult`, `imputeFeatureVector`, `SchemaValidationError` (whose `issues` array reports *every* violation, not just the first, so a broken producer can be fixed in one pass), the type/spec exports, and four synthetic examples.

### Acceptance criteria

- [x] **Inputs and outputs have named fields and types** — every field of both contracts is specified with its type, unit and range, in the README table and as exported TypeScript interfaces.
- [x] **Missing and invalid data behavior is described** — and enforced: the rules above are validator behaviour with tests, not recommendations.
- [x] **Example data contains no sensitive information** — every example was fabricated by hand. `subjectId`s are literal placeholders (`synthetic-account-0001`), not hashes or obfuscations of anything real; no field derives from a real account, person, or ledger entry. A test asserts every exported example's `subjectId` begins with `synthetic-`, so a real identifier cannot be pasted in without failing CI.

## Testing done

Added `packages/chenai-mlflow/src/index.test.ts` — 38 Vitest cases covering: the documented examples validating (so a doc example that stops being valid fails CI), a JSON round trip (the wire format), every numeric feature accepted at both documented bounds and as `null`, and rejection of absent keys, `undefined`, unknown fields, unsupported `schemaVersion`, PII-shaped `subjectId`, non-UTC/malformed timestamps, `NaN`/`Infinity`, fractional values in integer fields, numeric strings, out-of-range values, and — for `ModelResult` — nulls anywhere, floating version tags like `"latest"`, unknown `task`/`label`, and an omitted `imputedFields`. Also asserts multi-issue reporting and that `imputeFeatureVector`'s output matches the paired example result's `imputedFields`.

All commands run from the repo root, all passing:

```
$ pnpm install --no-frozen-lockfile
Done in 10s using pnpm v9.15.9

$ pnpm --filter @chenaikit/chenai-mlflow run build      # tsc -p tsconfig.json
(clean — no diagnostics; also verified with --noEmit)

$ pnpm --filter @chenaikit/chenai-mlflow run test       # vitest run
 ✓ src/index.test.ts (38 tests) 43ms
 Test Files  1 passed (1)
      Tests  38 passed (38)
```

Because this touches `packages/**`, `Backend CI` runs `apps/backend` too. Verified locally that this branch leaves it green:

```
$ cd apps/backend
$ pnpm exec prisma generate     # ok
$ pnpm run lint                 # eslint . — clean
$ pnpm exec tsc -p tsconfig.json --noEmit   # clean
$ pnpm run test                 # 7 passed (7)
$ pnpm run build                # clean
```

`contracts.yml` and `frontend.yml` do not trigger — no paths under `contracts/` or `apps/frontend/` are touched.

### One note on `pnpm run lint` for this package

`packages/chenai-mlflow/package.json` already declared `"lint": "eslint ."`, but there is no ESLint config for `packages/*` — the only configs in the repo are `apps/backend/eslint.config.js` and `apps/frontend/eslint.config.js`. So that script fails with `ESLint couldn't find an eslint.config.(js|mjs|cjs) file`, on `main` exactly as on this branch. This is **pre-existing and not triggered by CI** (`backend.yml`'s `packages` job only runs `build --if-present || true`), so I've deliberately left it alone rather than inventing a lint config as drive-by scope. Happy to open a separate issue for wiring ESLint across `packages/*` if that's wanted.

## Checklist

- [x] Branch name follows `CONTRIBUTING.md` — `docs/ml-data-contracts`, branched from an up-to-date `main`.
- [x] Conventional Commits with correct scopes — `feat(chenai-mlflow): …` and `docs(ml): …`.
- [x] Scoped to one domain — only `ml/README.md` and `packages/chenai-mlflow/src/`. Nothing under `apps/` or `contracts/` touched.
- [x] No generated artifacts, `.env` files, or secrets. **No lockfile churn**: `pnpm install` reintroduces an unrelated `@testing-library/dom` entry left over from `e467f6e`, which I reverted so it stays out of this diff.
- [x] No UI change, so no screenshots apply.
- [ ] **Size — above the ~600-line guidance, deliberately not split.** ~1,350 added lines across three files: `ml/README.md` (333), `packages/chenai-mlflow/src/index.ts` (703), `packages/chenai-mlflow/src/index.test.ts` (317). Splitting would mean landing the prose and the code that enforces it in separate PRs, which is exactly the drift this change exists to prevent — the README's field table and the validator's `NUMERIC_FEATURE_SPECS` must be reviewed against each other. The bulk is also declarative rather than dense: the spec table and the doc comments are one block per field, and roughly a quarter of the diff is tests. Happy to split into `types` / `validators` / `docs` if a reviewer would rather read it that way.
- [x] No follow-up work left undocumented — the only deferred item is the `packages/*` ESLint config noted above.

