### PR TITLE
feat(backend): add centralized error handling

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -48,6 +48,88 @@ The following routes are **not** subject to rate limiting:
 
 Exemptions are enforced in the middleware layer and do not count against a client's rate limit quota.
 
+## Error Handling
+
+Every response — success or failure — carries an `X-Request-Id` header (set by
+`middleware/requestId.ts`, or reused from an inbound `X-Request-Id` header if
+one is already set) so a request can be traced end to end.
+
+All errors flow through one centralized handler
+(`middleware/errorHandler.ts`, mounted last in `src/index.ts`) so clients get
+one consistent response shape regardless of what failed:
+
+```json
+{
+  "error": "not_found",
+  "message": "The requested resource was not found.",
+  "requestId": "b2b1a6e0-..."
+}
+```
+
+`error` is a stable, machine-readable code — safe for clients to branch on.
+`message` is safe to display as-is. An error can optionally include a
+`details` object with safe, structured extra context (e.g. which field
+failed validation).
+
+### Known errors
+
+Route handlers signal an expected failure by throwing one of the typed
+errors from `src/errors/`:
+
+| Class               | Status | `error` code       |
+| -------------------- | ------ | ------------------- |
+| `ValidationError`    | 400    | `validation_error`  |
+| `UnauthorizedError`  | 401    | `unauthorized`      |
+| `ForbiddenError`     | 403    | `forbidden`          |
+| `NotFoundError`      | 404    | `not_found`          |
+| `ConflictError`      | 409    | `conflict`            |
+| `DatabaseError`      | 500    | `database_error`    |
+
+A request to a route that doesn't exist gets the same `not_found` shape
+(`middleware/notFoundHandler.ts`) instead of Express's default HTML 404 page.
+
+Known Prisma errors are mapped automatically (`errors/mapPrismaError.ts`) so
+a route doesn't need its own try/catch for common database failures — a
+unique constraint violation becomes a 409 `conflict`, a missing record
+becomes a 404 `not_found`, a foreign key violation becomes a 400
+`validation_error`, and anything else recognisably-Prisma-but-unmapped
+becomes a generic 500 `database_error`. The raw Prisma error message (which
+can include table/column names and query fragments) is never sent to the
+client — only logged server-side.
+
+### Unexpected errors
+
+Anything that isn't a known error type is treated as unexpected: the client
+gets a generic `500 internal_error` with a `requestId`, and the **full**
+error — including its stack trace — is logged server-side only
+(`console.error` by default; inject a different sink via
+`createErrorHandler({ log })`). Stack traces never appear in a response
+body.
+
+### Writing an async route handler
+
+Express 4 doesn't catch a rejected promise from an async route handler on
+its own — wrap it in `asyncHandler` so a thrown/rejected error reaches the
+centralized handler instead of crashing the process:
+
+```ts
+import { asyncHandler } from "./middleware/asyncHandler.js";
+import { NotFoundError } from "./errors/index.js";
+
+app.get(
+  "/creators/:id",
+  asyncHandler(async (req, res) => {
+    const creator = await prisma.creator.findUniqueOrThrow({ where: { id: req.params.id } });
+    // ...or throw a typed error explicitly:
+    // if (!creator) throw new NotFoundError("No creator with that id.");
+    res.json(creator);
+  }),
+);
+```
+
+A synchronous `throw` in a non-async handler doesn't need `asyncHandler` —
+Express already catches those.
+
 ## Development
 
 ### Setup

--- a/apps/backend/src/errors/AppError.ts
+++ b/apps/backend/src/errors/AppError.ts
@@ -1,0 +1,71 @@
+/**
+ * Base class for errors the application raises deliberately (as opposed to
+ * unexpected/unknown failures). Every AppError carries a stable,
+ * machine-readable `code` and an HTTP-safe `message` that is safe to send to
+ * a client as-is — never raw database errors, stack traces, or internal
+ * details.
+ */
+export class AppError extends Error {
+  readonly statusCode: number;
+  readonly code: string;
+  /** Optional safe, structured extra context (e.g. which field failed validation). */
+  readonly details?: Record<string, unknown>;
+
+  constructor(code: string, message: string, statusCode: number, details?: Record<string, unknown>) {
+    super(message);
+    this.name = "AppError";
+    this.code = code;
+    this.statusCode = statusCode;
+    this.details = details;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export class ValidationError extends AppError {
+  constructor(message = "The request could not be validated.", details?: Record<string, unknown>) {
+    super("validation_error", message, 400, details);
+    this.name = "ValidationError";
+  }
+}
+
+export class UnauthorizedError extends AppError {
+  constructor(message = "Authentication is required.") {
+    super("unauthorized", message, 401);
+    this.name = "UnauthorizedError";
+  }
+}
+
+export class ForbiddenError extends AppError {
+  constructor(message = "You do not have permission to perform this action.") {
+    super("forbidden", message, 403);
+    this.name = "ForbiddenError";
+  }
+}
+
+export class NotFoundError extends AppError {
+  constructor(message = "The requested resource was not found.") {
+    super("not_found", message, 404);
+    this.name = "NotFoundError";
+  }
+}
+
+export class ConflictError extends AppError {
+  constructor(message = "The request conflicts with the current state of the resource.", details?: Record<string, unknown>) {
+    super("conflict", message, 409, details);
+    this.name = "ConflictError";
+  }
+}
+
+/**
+ * A database operation failed in a way we recognise (e.g. a Prisma error we
+ * don't have a more specific mapping for) but don't want to expose details
+ * of to the client. The underlying error is always logged server-side by
+ * the error handler; this class exists so the response stays generic and
+ * safe regardless of what the database actually said.
+ */
+export class DatabaseError extends AppError {
+  constructor(message = "A database error occurred.") {
+    super("database_error", message, 500);
+    this.name = "DatabaseError";
+  }
+}

--- a/apps/backend/src/errors/index.ts
+++ b/apps/backend/src/errors/index.ts
@@ -1,0 +1,10 @@
+export {
+  AppError,
+  ValidationError,
+  UnauthorizedError,
+  ForbiddenError,
+  NotFoundError,
+  ConflictError,
+  DatabaseError,
+} from "./AppError.js";
+export { mapPrismaError } from "./mapPrismaError.js";

--- a/apps/backend/src/errors/mapPrismaError.test.ts
+++ b/apps/backend/src/errors/mapPrismaError.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { Prisma } from "@prisma/client";
+import { mapPrismaError } from "./mapPrismaError.js";
+import { ConflictError, DatabaseError, NotFoundError, ValidationError } from "./AppError.js";
+
+function knownError(code: string, meta?: Record<string, unknown>) {
+  return new Prisma.PrismaClientKnownRequestError("Prisma internal message with table/column detail", {
+    code,
+    clientVersion: "5.22.0",
+    meta,
+  });
+}
+
+describe("mapPrismaError", () => {
+  it("maps a unique constraint violation (P2002) to a 409 ConflictError with a safe message", () => {
+    const mapped = mapPrismaError(knownError("P2002", { target: ["email"] }));
+    expect(mapped).toBeInstanceOf(ConflictError);
+    expect(mapped?.statusCode).toBe(409);
+    expect(mapped?.code).toBe("conflict");
+    expect(mapped?.message).not.toMatch(/prisma internal/i);
+  });
+
+  it("maps a record-not-found (P2025) to a 404 NotFoundError", () => {
+    const mapped = mapPrismaError(knownError("P2025"));
+    expect(mapped).toBeInstanceOf(NotFoundError);
+    expect(mapped?.statusCode).toBe(404);
+  });
+
+  it("maps a foreign key violation (P2003) to a 400 ValidationError", () => {
+    const mapped = mapPrismaError(knownError("P2003"));
+    expect(mapped).toBeInstanceOf(ValidationError);
+    expect(mapped?.statusCode).toBe(400);
+  });
+
+  it("falls back to a generic 500 DatabaseError for a recognised-but-unmapped code, never leaking the raw message", () => {
+    const mapped = mapPrismaError(knownError("P2034"));
+    expect(mapped).toBeInstanceOf(DatabaseError);
+    expect(mapped?.statusCode).toBe(500);
+    expect(mapped?.message).not.toMatch(/prisma internal/i);
+  });
+
+  it("maps a validation error to a 400 ValidationError", () => {
+    const mapped = mapPrismaError(new Prisma.PrismaClientValidationError("some raw zod-ish prisma text", { clientVersion: "5.22.0" }));
+    expect(mapped).toBeInstanceOf(ValidationError);
+    expect(mapped?.statusCode).toBe(400);
+  });
+
+  it("returns null for a plain, non-Prisma error", () => {
+    expect(mapPrismaError(new Error("boom"))).toBeNull();
+    expect(mapPrismaError("not even an error")).toBeNull();
+  });
+});

--- a/apps/backend/src/errors/mapPrismaError.ts
+++ b/apps/backend/src/errors/mapPrismaError.ts
@@ -1,0 +1,52 @@
+import { Prisma } from "@prisma/client";
+import { AppError, ConflictError, DatabaseError, NotFoundError, ValidationError } from "./AppError.js";
+
+/**
+ * Maps a Prisma error to the equivalent AppError, so known database failure
+ * modes get a stable status code and a safe message instead of leaking
+ * Prisma's internal error text (which can include table/column names and
+ * raw query fragments) to the client.
+ *
+ * Returns null for anything that isn't a Prisma error — callers should
+ * treat that as "not a known database error" and fall through to the
+ * generic unexpected-error path.
+ */
+export function mapPrismaError(err: unknown): AppError | null {
+  if (err instanceof Prisma.PrismaClientKnownRequestError) {
+    switch (err.code) {
+      // Unique constraint violation.
+      case "P2002": {
+        const target = Array.isArray(err.meta?.target) ? err.meta?.target.join(", ") : undefined;
+        return new ConflictError(
+          target ? `A record with this ${target} already exists.` : "A record with these values already exists.",
+        );
+      }
+      // Record not found (e.g. update/delete on a missing row).
+      case "P2025":
+        return new NotFoundError("The requested resource was not found.");
+      // Foreign key constraint violation.
+      case "P2003":
+        return new ValidationError("The request refers to a related resource that does not exist.");
+      // Required relation/value missing.
+      case "P2011":
+      case "P2012":
+        return new ValidationError("A required value is missing.");
+      default:
+        return new DatabaseError();
+    }
+  }
+
+  if (err instanceof Prisma.PrismaClientValidationError) {
+    return new ValidationError("The request could not be validated.");
+  }
+
+  if (
+    err instanceof Prisma.PrismaClientUnknownRequestError ||
+    err instanceof Prisma.PrismaClientInitializationError ||
+    err instanceof Prisma.PrismaClientRustPanicError
+  ) {
+    return new DatabaseError();
+  }
+
+  return null;
+}

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -5,6 +5,9 @@
 import express from "express";
 import { PrismaClient } from "@prisma/client";
 import { apiLimiter } from "./middleware/rateLimiter.js";
+import { requestId } from "./middleware/requestId.js";
+import { notFoundHandler } from "./middleware/notFoundHandler.js";
+import { errorHandler } from "./middleware/errorHandler.js";
 import { createGracefulShutdown, registerShutdownSignals } from "./lifecycle.js";
 
 const app = express();
@@ -13,6 +16,10 @@ const shutdownTimeoutMs = Number(process.env.SHUTDOWN_TIMEOUT_MS ?? 10_000);
 
 const prisma = new PrismaClient();
 
+// Assign a request ID before anything else, so it's available to every
+// downstream middleware, route, and the error handler.
+app.use(requestId);
+
 // Apply rate limiting to all requests
 app.use(apiLimiter);
 
@@ -20,6 +27,12 @@ app.use(apiLimiter);
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", service: "chenaikit-backend" });
 });
+
+// Centralized error handling: notFoundHandler catches unmatched routes,
+// errorHandler is the final middleware (four-argument signature required by
+// Express to be recognised as an error handler) and must stay last.
+app.use(notFoundHandler);
+app.use(errorHandler);
 
 const server = app.listen(port, () => {
   console.log(`[backend] listening on :${port}`);

--- a/apps/backend/src/middleware/asyncHandler.ts
+++ b/apps/backend/src/middleware/asyncHandler.ts
@@ -1,0 +1,15 @@
+import type { NextFunction, Request, RequestHandler, Response } from "express";
+
+/**
+ * Wraps an async route handler so a rejected promise reaches the centralized
+ * error handler via `next(err)`. Express 4 does not do this automatically —
+ * an unhandled rejection in an async handler would otherwise crash the
+ * process instead of producing a safe error response.
+ */
+export function asyncHandler(
+  handler: (req: Request, res: Response, next: NextFunction) => Promise<unknown>,
+): RequestHandler {
+  return (req, res, next) => {
+    handler(req, res, next).catch(next);
+  };
+}

--- a/apps/backend/src/middleware/errorHandler.test.ts
+++ b/apps/backend/src/middleware/errorHandler.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import request from "supertest";
+import { Prisma } from "@prisma/client";
+import { requestId } from "./requestId.js";
+import { asyncHandler } from "./asyncHandler.js";
+import { notFoundHandler } from "./notFoundHandler.js";
+import { createErrorHandler } from "./errorHandler.js";
+import { ValidationError, NotFoundError, ConflictError } from "../errors/index.js";
+
+describe("centralized error handling", () => {
+  let app: express.Application;
+  let log: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    log = vi.fn();
+    app = express();
+    app.use(express.json());
+    app.use(requestId);
+
+    app.get("/known/validation", () => {
+      throw new ValidationError("The 'amount' field must be a positive number.", { field: "amount" });
+    });
+    app.get("/known/not-found", () => {
+      throw new NotFoundError("No creator with that address.");
+    });
+    app.get("/known/conflict", () => {
+      throw new ConflictError("A record with this email already exists.");
+    });
+    app.get(
+      "/known/prisma-unique",
+      asyncHandler(async () => {
+        throw new Prisma.PrismaClientKnownRequestError("Unique constraint failed on the fields: (`email`)", {
+          code: "P2002",
+          clientVersion: "5.22.0",
+          meta: { target: ["email"] },
+        });
+      }),
+    );
+    app.get(
+      "/unknown/async",
+      asyncHandler(async () => {
+        throw new TypeError("Cannot read properties of undefined (reading 'foo')");
+      }),
+    );
+    app.get("/unknown/sync", () => {
+      throw new Error("something truly unexpected");
+    });
+    app.get("/ok", (_req, res) => {
+      res.json({ ok: true });
+    });
+
+    app.use(notFoundHandler);
+    app.use(createErrorHandler({ log }));
+  });
+
+  it("returns a stable status code and safe body for a known validation error", async () => {
+    const res = await request(app).get("/known/validation");
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({
+      error: "validation_error",
+      message: "The 'amount' field must be a positive number.",
+      requestId: expect.any(String),
+      details: { field: "amount" },
+    });
+  });
+
+  it("returns a stable status code for a known not-found error", async () => {
+    const res = await request(app).get("/known/not-found");
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("not_found");
+  });
+
+  it("returns a stable status code for a known conflict error", async () => {
+    const res = await request(app).get("/known/conflict");
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe("conflict");
+  });
+
+  it("maps a known Prisma error (thrown from an async handler) to its safe status/code", async () => {
+    const res = await request(app).get("/known/prisma-unique");
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe("conflict");
+    expect(JSON.stringify(res.body)).not.toMatch(/unique constraint failed/i);
+  });
+
+  it("returns a generic 500 with a request ID for an unexpected async error, without leaking the message or a stack trace", async () => {
+    const res = await request(app).get("/unknown/async");
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("internal_error");
+    expect(res.body.requestId).toEqual(expect.any(String));
+    expect(res.body).not.toHaveProperty("stack");
+    expect(JSON.stringify(res.body)).not.toMatch(/Cannot read properties/i);
+  });
+
+  it("returns a generic 500 with a request ID for an unexpected synchronous error", async () => {
+    const res = await request(app).get("/unknown/sync");
+    expect(res.status).toBe(500);
+    expect(res.body.requestId).toEqual(expect.any(String));
+    expect(JSON.stringify(res.body)).not.toMatch(/something truly unexpected/i);
+  });
+
+  it("logs the full error server-side (stack included) for an unexpected failure", async () => {
+    await request(app).get("/unknown/sync");
+    expect(log).toHaveBeenCalledTimes(1);
+    const event = log.mock.calls[0][0];
+    expect(event.statusCode).toBe(500);
+    expect(event.error).toBeInstanceOf(Error);
+    expect(event.error.stack).toContain("something truly unexpected");
+  });
+
+  it("logs known errors too, with their real status code", async () => {
+    await request(app).get("/known/not-found");
+    expect(log).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 404 }));
+  });
+
+  it("reuses an inbound X-Request-Id and echoes it back on both success and error responses", async () => {
+    const ok = await request(app).get("/ok").set("X-Request-Id", "trace-abc-123");
+    expect(ok.headers["x-request-id"]).toBe("trace-abc-123");
+
+    const failed = await request(app).get("/unknown/sync").set("X-Request-Id", "trace-xyz-789");
+    expect(failed.body.requestId).toBe("trace-xyz-789");
+  });
+
+  it("returns a stable 404 shape for a route that doesn't exist, instead of Express's default HTML page", async () => {
+    const res = await request(app).get("/this/route/does/not/exist");
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("not_found");
+    expect(res.headers["content-type"]).toMatch(/json/);
+  });
+});

--- a/apps/backend/src/middleware/errorHandler.ts
+++ b/apps/backend/src/middleware/errorHandler.ts
@@ -1,0 +1,84 @@
+import { randomUUID } from "node:crypto";
+import type { NextFunction, Request, Response } from "express";
+import { AppError, mapPrismaError } from "../errors/index.js";
+
+export interface ErrorBody {
+  error: string;
+  message: string;
+  requestId?: string;
+  details?: Record<string, unknown>;
+}
+
+export function buildErrorBody(err: AppError, requestId?: string): ErrorBody {
+  return {
+    error: err.code,
+    message: err.message,
+    ...(requestId ? { requestId } : {}),
+    ...(err.details ? { details: err.details } : {}),
+  };
+}
+
+interface ErrorLogEvent {
+  requestId?: string;
+  method: string;
+  path: string;
+  statusCode: number;
+  /** The original error, stack and all — for server-side logging only, never sent to the client. */
+  error: unknown;
+}
+
+export interface ErrorHandlerOptions {
+  /** Injectable for tests and alternate log sinks; defaults to console.error. */
+  log?: (event: ErrorLogEvent) => void;
+}
+
+function defaultLog(event: ErrorLogEvent): void {
+  const { error, ...meta } = event;
+  console.error(
+    `[error] ${meta.method} ${meta.path} -> ${meta.statusCode}${meta.requestId ? ` (request ${meta.requestId})` : ""}`,
+    error instanceof Error ? (error.stack ?? error.message) : error,
+  );
+}
+
+/**
+ * Builds the final Express error-handling middleware. Must be mounted after
+ * every route (and after notFoundHandler) — Express recognises an error
+ * middleware by its four-argument signature.
+ *
+ * - AppError (or an error mappable to one, e.g. a known Prisma error): the
+ *   error's own stable code/message/status is returned as-is.
+ * - Anything else is treated as unexpected: the full error is logged
+ *   server-side (stack included) and the client gets a generic, safe body
+ *   with a request ID for support/log correlation — never the raw error.
+ */
+export function createErrorHandler(options: ErrorHandlerOptions = {}) {
+  const log = options.log ?? defaultLog;
+
+  return function errorHandler(err: unknown, req: Request, res: Response, next: NextFunction): void {
+    // Delegate to Express's default handler once headers are already sent —
+    // it's unsafe to write a new response body at that point.
+    if (res.headersSent) {
+      next(err);
+      return;
+    }
+
+    const known = err instanceof AppError ? err : mapPrismaError(err);
+
+    if (known) {
+      log({ requestId: req.id, method: req.method, path: req.path, statusCode: known.statusCode, error: err });
+      res.status(known.statusCode).json(buildErrorBody(known, req.id));
+      return;
+    }
+
+    const requestId = req.id ?? randomUUID();
+    log({ requestId, method: req.method, path: req.path, statusCode: 500, error: err });
+    res.status(500).json({
+      error: "internal_error",
+      message: "An unexpected error occurred. Contact support with the request ID below if this persists.",
+      requestId,
+    });
+  };
+}
+
+/** Default instance, wired into the app in index.ts. Use createErrorHandler() directly to inject a custom logger (e.g. in tests). */
+export const errorHandler = createErrorHandler();

--- a/apps/backend/src/middleware/notFoundHandler.ts
+++ b/apps/backend/src/middleware/notFoundHandler.ts
@@ -1,0 +1,13 @@
+import type { Request, Response } from "express";
+import { NotFoundError } from "../errors/index.js";
+import { buildErrorBody } from "./errorHandler.js";
+
+/**
+ * Mounted after every route. Anything that reaches this point matched no
+ * route, so it gets the same stable 404 shape as an explicit NotFoundError
+ * thrown from inside a handler, instead of Express's default HTML page.
+ */
+export function notFoundHandler(req: Request, res: Response): void {
+  const error = new NotFoundError(`No route matches ${req.method} ${req.path}.`);
+  res.status(error.statusCode).json(buildErrorBody(error, req.id));
+}

--- a/apps/backend/src/middleware/requestId.ts
+++ b/apps/backend/src/middleware/requestId.ts
@@ -1,0 +1,25 @@
+import { randomUUID } from "node:crypto";
+import type { NextFunction, Request, Response } from "express";
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Express {
+    interface Request {
+      id: string;
+    }
+  }
+}
+
+/**
+ * Assigns a stable request ID to every request — reused from an inbound
+ * `X-Request-Id` header when a caller (e.g. a gateway) already set one, so
+ * a trace stays correlated end to end. Set early, before routes, so it's
+ * available to logging and to the error handler regardless of where a
+ * request fails.
+ */
+export function requestId(req: Request, res: Response, next: NextFunction): void {
+  const inbound = req.headers["x-request-id"];
+  req.id = (typeof inbound === "string" && inbound.trim()) || randomUUID();
+  res.setHeader("X-Request-Id", req.id);
+  next();
+}


### PR DESCRIPTION
## Summary

Adds centralized error handling to `apps/backend`: typed application errors (`ValidationError`, `UnauthorizedError`, `ForbiddenError`, `NotFoundError`, `ConflictError`, `DatabaseError`), a final Express error-handling middleware, and automatic mapping of known Prisma errors (unique constraint violation, record-not-found, foreign key violation) to the equivalent typed error — so a route doesn't need its own try/catch for common database failures.

Known errors get a stable status code and a safe `{ error, message, requestId }` body. Unexpected/unknown failures always get a generic `500 internal_error` with a `requestId` for support/log correlation — the full error, stack included, is logged server-side only and never sent to the client.

Also adds:
- `middleware/requestId.ts` — assigns (or reuses an inbound) `X-Request-Id` on every request, available to logging and the error handler regardless of where a request fails.
- `middleware/notFoundHandler.ts` — unmatched routes get the same `not_found` JSON shape instead of Express's default HTML 404 page.
- `middleware/asyncHandler.ts` — Express 4 doesn't forward a rejected promise from an async route handler to the error middleware on its own; this wraps a handler so it does.

The backend was genuinely nascent (just `/health` plus rate-limiting and graceful-shutdown middleware, no real routes yet) — this lays the error-handling foundation for routes as they're added, rather than retrofitting existing ones.

Closes #305.

## Testing done

- `cd apps/backend && npx vitest run` — 30/30 pass (16 new: 6 for `mapPrismaError`, 10 integration tests for the error handler + not-found handler, covering known-error status codes, a real Prisma `P2002` error thrown from an async handler, unexpected sync/async errors never leaking their message or a stack trace, request-ID propagation, and that the injectable logger receives the full error).
- `cd apps/backend && npx tsc -p tsconfig.json --noEmit` — clean.
- `cd apps/backend && npx eslint .` — clean.
- `cd apps/backend && npm run build` — clean.
- `pnpm --filter "./packages/*" run build` — clean (the "Shared packages build" CI job).

## Screenshots

N/A — no UI surface (backend-only change).

## Checklist

- [x] Branch follows the naming convention (`feat/`, `fix/`, `chore/`, `docs/`, `refactor/`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope): summary`)
- [x] The PR is scoped to one domain / one issue, with no unrelated churn
- [x] All CI checks are green (see the CI requirements in `CONTRIBUTING.md`)
- [x] Docs updated where behavior changed (`apps/backend/README.md` — new "Error Handling" section)
- [x] Screenshots attached for UI changes (N/A)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added standardized backend error responses for validation, authentication, authorization, missing resources, conflicts, and database failures.
  * Added request IDs to responses for easier issue tracking and troubleshooting.
  * Added consistent JSON responses for unknown routes and unexpected server errors.
  * Added safe handling for asynchronous route failures and database errors.

* **Documentation**
  * Added backend documentation covering error handling and request tracking.

* **Tests**
  * Added comprehensive coverage for error mapping, request IDs, route failures, and safe error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->